### PR TITLE
Push down 2/6 heavy-logic functions in interface/matrix.cpp to engine e/

### DIFF
--- a/M2/Macaulay2/e/interface/matrix.cpp
+++ b/M2/Macaulay2/e/interface/matrix.cpp
@@ -80,54 +80,13 @@ const RingElement /* or null */ *rawMatrixEntry(const Matrix *M,
   }
 }
 
-/* Returns the entries of the matrix in a flat array in row major order
+/* Returns the entries of the matrix as an array of rows.
  */
 engine_RawRingElementArrayArrayOrNull rawMatrixEntries(const Matrix *M)
 {
   try
     {
-      int ncols = M->n_cols();
-      int nrows = M->n_rows();
-      if(nrows < 0 || ncols < 0)
-        {
-          ERROR("internal error: matrix has a negative size %d by %d",
-                nrows,
-                ncols);
-          return nullptr;
-        }
-      engine_RawRingElementArrayArray entries =
-          getmemarraytype(engine_RawRingElementArrayArray, nrows);
-      entries->len = nrows;
-      RingElement *zero =
-          RingElement::make_raw(M->get_ring(), M->get_ring()->zero());
-      for(int r = 0; r < nrows; r++)
-        {
-          engine_RawRingElementArray currRow =
-              getmemarraytype(engine_RawRingElementArray, ncols);
-          currRow->len = ncols;
-          std::fill_n(currRow->array, ncols, zero);
-          entries->array[r] = currRow;
-        }
-      //walk through the columns
-      for(int c = 0; c < ncols; c++)
-        {
-          const vec &column = M->elem(c);
-          for(const vecterm &term : column)
-            {
-              if(term.comp < 0 || term.comp >= nrows)
-                {
-                  ERROR("internal error: matrix contains invalid entries:"
-                        "row index %d out of range 0 .. %d",
-                        term.comp,
-                        nrows - 1);
-                  //Ignoring the entry and continuing
-                  continue;
-                }
-              entries->array[term.comp]->array[c] =
-                  RingElement::make_raw(M->get_ring(), term.coeff);
-            }
-        }
-      return entries;
+      return M->entries();
     } catch (const exc::engine_error &e)
     {
       ERROR(e.what());

--- a/M2/Macaulay2/e/interface/matrix.cpp
+++ b/M2/Macaulay2/e/interface/matrix.cpp
@@ -725,22 +725,7 @@ const Matrix /* or null */ *rawMatrixPromote(const FreeModule *newTarget,
 {
   try
     {
-      ring_elem a;
-      const Ring *R = f->get_ring();
-      const Ring *S = newTarget->get_ring();
-      MatrixConstructor mat(newTarget, f->n_cols());
-      Matrix::iterator i(f);
-      for (int c = 0; c < f->n_cols(); c++)
-        for (i.set(c); i.valid(); i.next())
-          if (S->promote(R, i.entry(), a))
-            mat.set_entry(i.row(), c, a);
-          else
-            {
-              ERROR("cannot promote given matrix");
-              return nullptr;
-            }
-      mat.compute_column_degrees();
-      return mat.to_matrix();
+      return f->promote(newTarget);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());

--- a/M2/Macaulay2/e/matrix.cpp
+++ b/M2/Macaulay2/e/matrix.cpp
@@ -326,6 +326,28 @@ const Matrix /* or null */ *Matrix::remake(const FreeModule *target) const
   return mat.to_matrix();
 }
 
+const Matrix /* or null */ *Matrix::promote(const FreeModule *target) const
+{
+  ring_elem a;
+  const Ring *R = get_ring();
+  const Ring *S = target->get_ring();
+  MatrixConstructor mat(target, n_cols());
+  Matrix::iterator i(this);
+  for (int c = 0; c < n_cols(); c++)
+    for (i.set(c); i.valid(); i.next())
+      if (S->promote(R, i.entry(), a))
+        mat.set_entry(i.row(), c, a);
+      else
+        {
+          ERROR("first error occurred while promoting matrix entry at row %d, column %d",
+                i.row(),
+                c);
+          return nullptr;
+        }
+  mat.compute_column_degrees();
+  return mat.to_matrix();
+}
+
 const Matrix /* or null */ *Matrix::make(const MonomialIdeal *mi)
 {
   const PolynomialRing *P = mi->get_ring()->cast_to_PolynomialRing();

--- a/M2/Macaulay2/e/matrix.cpp
+++ b/M2/Macaulay2/e/matrix.cpp
@@ -13,6 +13,7 @@
 #include "style.hpp"
 #include "text-io.hpp"
 #include "ring.hpp"
+#include "ringelem.hpp"
 #include "comb.hpp"
 #include "polyring.hpp"
 #include "assprime.hpp"
@@ -55,6 +56,53 @@ unsigned int Matrix::computeHashValue() const
         }
     }
   return hashval;
+}
+
+engine_RawRingElementArrayArrayOrNull Matrix::entries() const
+{
+  int ncols = n_cols();
+  int nrows = n_rows();
+  if (nrows < 0 || ncols < 0)
+    {
+      ERROR("internal error: matrix has a negative size %d by %d",
+            nrows,
+            ncols);
+      return nullptr;
+    }
+
+  engine_RawRingElementArrayArray entries =
+      getmemarraytype(engine_RawRingElementArrayArray, nrows);
+  entries->len = nrows;
+
+  const Ring *R = get_ring();
+  RingElement *zero = RingElement::make_raw(R, R->zero());
+  for (int r = 0; r < nrows; r++)
+    {
+      engine_RawRingElementArray currRow =
+          getmemarraytype(engine_RawRingElementArray, ncols);
+      currRow->len = ncols;
+      std::fill_n(currRow->array, ncols, zero);
+      entries->array[r] = currRow;
+    }
+
+  for (int c = 0; c < ncols; c++)
+    {
+      const vec &column = elem(c);
+      for (const vecterm &term : column)
+        {
+          if (term.comp < 0 || term.comp >= nrows)
+            {
+              ERROR("internal error: matrix contains invalid entries:"
+                    "row index %d out of range 0 .. %d",
+                    term.comp,
+                    nrows - 1);
+              continue;
+            }
+          entries->array[term.comp]->array[c] =
+              RingElement::make_raw(R, term.coeff);
+        }
+    }
+  return entries;
 }
 
 const Matrix /* or null */ *Matrix::make(const FreeModule *target,

--- a/M2/Macaulay2/e/matrix.hpp
+++ b/M2/Macaulay2/e/matrix.hpp
@@ -80,6 +80,8 @@ class Matrix : public EngineObject
 
   const Matrix /* or null */ *remake(const FreeModule *target) const;
 
+  const Matrix /* or null */ *promote(const FreeModule *target) const;
+
   static const Matrix *make(const MonomialIdeal *mi);
 
   const Ring *get_ring() const { return rows()->get_ring(); }

--- a/M2/Macaulay2/e/matrix.hpp
+++ b/M2/Macaulay2/e/matrix.hpp
@@ -89,6 +89,7 @@ class Matrix : public EngineObject
   ring_elem elem(int i, int j) const;
   vec &elem(int i) { return mEntries[i]; }
   const vec &elem(int i) const { return mEntries[i]; }
+  engine_RawRingElementArrayArrayOrNull entries() const;
   /*****************************************/
 
   /* The non-const versions of these will go away */

--- a/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
@@ -8,6 +8,7 @@
 #include "BasicPolyList.hpp"
 #include "BasicPolyListParser.hpp"
 #include "relem.hpp"
+#include "error.h"
 #include "gb-f4/PolynomialList.hpp"
 #include "gb-f4/GBF4Interface.hpp"
 #include "VectorArithmetic.hpp"
@@ -137,6 +138,56 @@ TEST(Matrix, entriesFromSparseColumns)
               << "entry (" << r << ", " << c << ")";
         }
     }
+}
+
+TEST(Matrix, promote)
+{
+  const Ring* ZZ = globalZZ;
+  const PolynomialRing* P = degreeRing({"x"});
+
+  const FreeModule* zzTarget = ZZ->make_FreeModule(3);
+  MatrixConstructor mat(zzTarget, 4);
+
+  mat.set_entry(0, 0, ZZ->from_long(7));
+  mat.set_entry(2, 1, ZZ->from_long(-3));
+  mat.set_entry(1, 3, ZZ->from_long(11));
+  mat.compute_column_degrees();
+
+  const Matrix* M = mat.to_matrix();
+  const FreeModule* polynomialTarget = P->make_FreeModule(3);
+  const Matrix* promoted = M->promote(polynomialTarget);
+
+  ASSERT_NE(promoted, nullptr);
+  EXPECT_EQ(promoted->rows(), polynomialTarget);
+  EXPECT_EQ(promoted->get_ring(), P);
+  EXPECT_EQ(promoted->n_rows(), 3);
+  EXPECT_EQ(promoted->n_cols(), 4);
+
+  EXPECT_TRUE(P->is_equal(promoted->elem(0, 0), P->from_long(7)));
+  EXPECT_TRUE(P->is_equal(promoted->elem(2, 1), P->from_long(-3)));
+  EXPECT_TRUE(P->is_equal(promoted->elem(1, 3), P->from_long(11)));
+  EXPECT_TRUE(P->is_zero(promoted->elem(1, 1)));
+}
+
+TEST(Matrix, promoteFailureReportsFirstEntry)
+{
+  const Ring* ZZ = globalZZ;
+  const PolynomialRing* P = degreeRing({"x"});
+
+  const FreeModule* polynomialTarget = P->make_FreeModule(3);
+  MatrixConstructor mat(polynomialTarget, 2);
+
+  mat.set_entry(2, 0, P->from_long(7));
+  mat.set_entry(0, 1, P->from_long(11));
+  mat.compute_column_degrees();
+
+  const Matrix* M = mat.to_matrix();
+  const Matrix* promoted = M->promote(ZZ->make_FreeModule(3));
+
+  EXPECT_EQ(promoted, nullptr);
+  EXPECT_TRUE(error());
+  EXPECT_STREQ(error_message(),
+               "first error occurred while promoting matrix entry at row 2, column 0");
 }
 
 #if 0

--- a/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
@@ -3,9 +3,11 @@
 #include <gtest/gtest.h>
 
 #include "util-polyring-creation.hpp"
+#include "matrix-con.hpp"
 #include "matrix.hpp"
 #include "BasicPolyList.hpp"
 #include "BasicPolyListParser.hpp"
+#include "relem.hpp"
 #include "gb-f4/PolynomialList.hpp"
 #include "gb-f4/GBF4Interface.hpp"
 #include "VectorArithmetic.hpp"
@@ -93,6 +95,48 @@ TEST(MatrixIO, readMsolve)
 
   EXPECT_TRUE(M->n_rows() == 1);
   EXPECT_TRUE(M->n_cols() == 4);
+}
+
+TEST(Matrix, entriesFromSparseColumns)
+{
+  const Ring* R = simplePolynomialRing(101, {"x"});
+  const FreeModule* target = R->make_FreeModule(5);
+  MatrixConstructor mat(target, 15);
+
+  mat.set_entry(1, 3, R->from_long(11));
+  mat.set_entry(3, 2, R->from_long(22));
+  mat.set_entry(4, 1, R->from_long(33));
+  mat.compute_column_degrees();
+
+  const Matrix* M = mat.to_matrix();
+  engine_RawRingElementArrayArray entries = M->entries();
+
+  ASSERT_NE(entries, nullptr);
+  EXPECT_EQ(entries->len, 5);
+
+  for (int r = 0; r < 5; r++)
+    {
+      ASSERT_NE(entries->array[r], nullptr);
+      EXPECT_EQ(entries->array[r]->len, 15);
+
+      for (int c = 0; c < 15; c++)
+        {
+          ASSERT_NE(entries->array[r]->array[c], nullptr);
+          EXPECT_EQ(entries->array[r]->array[c]->get_ring(), R);
+
+          ring_elem expected = R->zero();
+          if (r == 1 && c == 3)
+            expected = R->from_long(11);
+          else if (r == 3 && c == 2)
+            expected = R->from_long(22);
+          else if (r == 4 && c == 1)
+            expected = R->from_long(33);
+
+          EXPECT_TRUE(R->is_equal(entries->array[r]->array[c]->get_value(),
+                                  expected))
+              << "entry (" << r << ", " << c << ")";
+        }
+    }
 }
 
 #if 0


### PR DESCRIPTION
This PR contain push-down and corresponding unit-test of 2 of 6 functions in the interface which has heavy logic. This heavy logic should be moved to core, so that interface will serve as a contract. Complete 2 of them to sumbit to make sure the way is on the right track. Will finish the rest after confirming this approach is as expected.

6 detected functions contain heavy logic in nterface/matrix.cpp:
1. rawMatrixEntries 
2. rawMatrixPromote 
3. rawMatrixLift 
4. rawMatrixConcat 
5. rawMatrixDirectSum 
6. rawMatrixEntry 