### PR TITLE
Clean up matrix.cpp in interface/

### DIFF
--- a/M2/Macaulay2/e/interface/matrix.cpp
+++ b/M2/Macaulay2/e/interface/matrix.cpp
@@ -57,21 +57,7 @@ const RingElement /* or null */ *rawMatrixEntry(const Matrix *M,
 {
   try
     {
-      if (r < 0 || r >= M->n_rows())
-        {
-          ERROR("matrix row index %d out of range 0 .. %d", r, M->n_rows() - 1);
-          return nullptr;
-        }
-      if (c < 0 || c >= M->n_cols())
-        {
-          ERROR("matrix column index %d out of range 0 .. %d",
-                c,
-                M->n_cols() - 1);
-          return nullptr;
-        }
-      ring_elem result;
-      result = M->elem(r, c);
-      return RingElement::make_raw(M->get_ring(), result);
+      return M->entry(r, c);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());

--- a/M2/Macaulay2/e/interface/matrix.cpp
+++ b/M2/Macaulay2/e/interface/matrix.cpp
@@ -15,7 +15,6 @@
 #include "interface/gmp-util.h"
 #include "interface/monoid.h"
 #include "mat.hpp"
-#include "matrix-con.hpp"
 #include "matrix.hpp"
 #include "mutablemat-defs.hpp"
 #include "relem.hpp"
@@ -288,36 +287,7 @@ const Matrix /* or null */ *rawMatrixConcat(const engine_RawMatrixArray Ms)
 {
   try
     {
-      unsigned int n = Ms->len;
-      if (n == 0)
-        {
-          ERROR("matrix concat: expects at least one matrix");
-          return nullptr;
-        }
-      const FreeModule *F = Ms->array[0]->rows();
-      const Ring *R = F->get_ring();
-      MatrixConstructor mat(Ms->array[0]->rows(), 0);
-      int next = 0;
-      for (unsigned int i = 0; i < n; i++)
-        {
-          const Matrix *M = Ms->array[i];
-          if (R != M->get_ring())
-            {
-              ERROR("matrix concat: different base rings");
-              return nullptr;
-            }
-          if (F->rank() != M->n_rows())
-            {
-              ERROR("matrix concat: row sizes are not equal");
-              return nullptr;
-            }
-          for (int j = 0; j < M->n_cols(); j++)
-            {
-              mat.append(R->copy_vec(M->elem(j)));
-              mat.set_column_degree(next++, M->cols()->degree(j));
-            }
-        }
-      return mat.to_matrix();
+      return Matrix::concat(Ms->len, Ms->array);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());

--- a/M2/Macaulay2/e/interface/matrix.cpp
+++ b/M2/Macaulay2/e/interface/matrix.cpp
@@ -295,31 +295,11 @@ const Matrix /* or null */ *rawMatrixConcat(const engine_RawMatrixArray Ms)
   }
 }
 
-const Matrix /* or null */ *rawMatrixDirectSum(
-    const engine_RawMatrixArray Ms)
+const Matrix /* or null */ *rawMatrixDirectSum(const engine_RawMatrixArray Ms)
 {
   try
     {
-      // Check that the matrices all have the same ring, and that there is
-      // at least one matrix.
-      unsigned int n = Ms->len;
-      if (n == 0)
-        {
-          ERROR("matrix direct sum: expects at least one matrix");
-          return nullptr;
-        }
-      const Matrix *result = Ms->array[0];
-      const Ring *R = result->get_ring();
-      for (unsigned int i = 1; i < n; i++)
-        if (R != Ms->array[i]->get_ring())
-          {
-            ERROR("matrix direct sum: different base rings");
-            return nullptr;
-          }
-      for (unsigned int i = 1; i < n; i++)
-        result = result->direct_sum(Ms->array[i]);
-
-      return result;
+      return Matrix::direct_sum(Ms->len, Ms->array);
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());

--- a/M2/Macaulay2/e/interface/matrix.cpp
+++ b/M2/Macaulay2/e/interface/matrix.cpp
@@ -737,25 +737,13 @@ const Matrix /* or null */ *rawMatrixLift(int *success_return,
                                             const FreeModule *newTarget,
                                             const Matrix *f)
 {
+  *success_return = 0;
   try
     {
-      ring_elem a;
-      const Ring *R = f->get_ring();
-      const Ring *S = newTarget->get_ring();
-      MatrixConstructor mat(newTarget, f->n_cols());
-      Matrix::iterator i(f);
-      for (int c = 0; c < f->n_cols(); c++)
-        for (i.set(c); i.valid(); i.next())
-          if (R->lift(S, i.entry(), a))
-            mat.set_entry(i.row(), c, a);
-          else
-            {
-              // ERROR("cannot lift given matrix");
-              return nullptr;
-            }
-      mat.compute_column_degrees();
+      const Matrix *result = f->lift(newTarget);
+      if (result == nullptr) return nullptr;
       *success_return = 1;
-      return mat.to_matrix();
+      return result;
   } catch (const exc::engine_error& e)
     {
       ERROR(e.what());

--- a/M2/Macaulay2/e/matrix.cpp
+++ b/M2/Macaulay2/e/matrix.cpp
@@ -718,6 +718,40 @@ Matrix *Matrix::concat(const Matrix &m) const
   return mat.to_matrix();
 }
 
+Matrix *Matrix::concat(unsigned int n, const Matrix *const matrices[])
+{
+  if (n == 0)
+    {
+      ERROR("matrix concat: expects at least one matrix");
+      return nullptr;
+    }
+
+  const FreeModule *F = matrices[0]->rows();
+  const Ring *R = F->get_ring();
+  MatrixConstructor mat(F, 0);
+  int next = 0;
+  for (unsigned int i = 0; i < n; i++)
+    {
+      const Matrix *M = matrices[i];
+      if (R != M->get_ring())
+        {
+          ERROR("matrix concat: different base rings");
+          return nullptr;
+        }
+      if (F->rank() != M->n_rows())
+        {
+          ERROR("matrix concat: row sizes are not equal");
+          return nullptr;
+        }
+      for (int j = 0; j < M->n_cols(); j++)
+        {
+          mat.append(R->copy_vec(M->elem(j)));
+          mat.set_column_degree(next++, M->cols()->degree(j));
+        }
+    }
+  return mat.to_matrix();
+}
+
 Matrix *Matrix::direct_sum(const Matrix *m) const
 {
   auto R = get_ring();

--- a/M2/Macaulay2/e/matrix.cpp
+++ b/M2/Macaulay2/e/matrix.cpp
@@ -752,6 +752,47 @@ Matrix *Matrix::concat(unsigned int n, const Matrix *const matrices[])
   return mat.to_matrix();
 }
 
+const Matrix *Matrix::direct_sum(unsigned int n, const Matrix *const matrices[])
+{
+  if (n == 0)
+    {
+      ERROR("matrix direct sum: expects at least one matrix");
+      return nullptr;
+    }
+
+  const Ring *R = matrices[0]->get_ring();
+  for (unsigned int i = 1; i < n; i++)
+    if (R != matrices[i]->get_ring())
+      {
+        ERROR("matrix direct sum: different base rings");
+        return nullptr;
+      }
+
+  if (n == 1) return matrices[0];
+
+  FreeModule *F = R->make_FreeModule();
+  FreeModule *G = R->make_FreeModule();
+  for (unsigned int i = 0; i < n; i++)
+    {
+      F->direct_sum_to(matrices[i]->rows());
+      G->direct_sum_to(matrices[i]->cols());
+    }
+
+  MatrixConstructor mat(F, G, nullptr);
+  int row_offset = 0;
+  int col_offset = 0;
+  for (unsigned int i = 0; i < n; i++)
+    {
+      const Matrix *M = matrices[i];
+      for (int j = 0; j < M->n_cols(); j++)
+        mat.set_column(col_offset + j,
+                       R->component_shift(row_offset, M->elem(j)));
+      row_offset += M->n_rows();
+      col_offset += M->n_cols();
+    }
+  return mat.to_matrix();
+}
+
 Matrix *Matrix::direct_sum(const Matrix *m) const
 {
   auto R = get_ring();

--- a/M2/Macaulay2/e/matrix.cpp
+++ b/M2/Macaulay2/e/matrix.cpp
@@ -58,6 +58,23 @@ unsigned int Matrix::computeHashValue() const
   return hashval;
 }
 
+const RingElement /* or null */ *Matrix::entry(int r, int c) const
+{
+  if (r < 0 || r >= n_rows())
+    {
+      ERROR("matrix row index %d out of range 0 .. %d", r, n_rows() - 1);
+      return nullptr;
+    }
+  if (c < 0 || c >= n_cols())
+    {
+      ERROR("matrix column index %d out of range 0 .. %d",
+            c,
+            n_cols() - 1);
+      return nullptr;
+    }
+  return RingElement::make_raw(get_ring(), elem(r, c));
+}
+
 engine_RawRingElementArrayArrayOrNull Matrix::entries() const
 {
   int ncols = n_cols();

--- a/M2/Macaulay2/e/matrix.cpp
+++ b/M2/Macaulay2/e/matrix.cpp
@@ -348,6 +348,28 @@ const Matrix /* or null */ *Matrix::promote(const FreeModule *target) const
   return mat.to_matrix();
 }
 
+const Matrix /* or null */ *Matrix::lift(const FreeModule *target) const
+{
+  ring_elem a;
+  const Ring *R = get_ring();
+  const Ring *S = target->get_ring();
+  MatrixConstructor mat(target, n_cols());
+  Matrix::iterator i(this);
+  for (int c = 0; c < n_cols(); c++)
+    for (i.set(c); i.valid(); i.next())
+      if (R->lift(S, i.entry(), a))
+        mat.set_entry(i.row(), c, a);
+      else
+        {
+          ERROR("first error occurred while lifting matrix entry at row %d, column %d",
+                i.row(),
+                c);
+          return nullptr;
+        }
+  mat.compute_column_degrees();
+  return mat.to_matrix();
+}
+
 const Matrix /* or null */ *Matrix::make(const MonomialIdeal *mi)
 {
   const PolynomialRing *P = mi->get_ring()->cast_to_PolynomialRing();

--- a/M2/Macaulay2/e/matrix.hpp
+++ b/M2/Macaulay2/e/matrix.hpp
@@ -81,6 +81,7 @@ class Matrix : public EngineObject
   const Matrix /* or null */ *remake(const FreeModule *target) const;
 
   const Matrix /* or null */ *promote(const FreeModule *target) const;
+  const Matrix /* or null */ *lift(const FreeModule *target) const;
 
   static const Matrix *make(const MonomialIdeal *mi);
 

--- a/M2/Macaulay2/e/matrix.hpp
+++ b/M2/Macaulay2/e/matrix.hpp
@@ -121,6 +121,8 @@ class Matrix : public EngineObject
   Matrix *scalar_mult(const ring_elem r, bool opposite_mult) const;
   Matrix *mult(const Matrix *m, bool opposite_mult) const;
   Matrix *concat(const Matrix &m) const;
+  static Matrix /* or null */ *concat(unsigned int n,
+                                      const Matrix *const matrices[]);
 
   static Matrix *identity(const FreeModule *F);
   static Matrix /* or null */ *zero(const FreeModule *F, const FreeModule *G);

--- a/M2/Macaulay2/e/matrix.hpp
+++ b/M2/Macaulay2/e/matrix.hpp
@@ -123,7 +123,6 @@ class Matrix : public EngineObject
   Matrix *concat(const Matrix &m) const;
   static Matrix /* or null */ *concat(unsigned int n,
                                       const Matrix *const matrices[]);
-
   static Matrix *identity(const FreeModule *F);
   static Matrix /* or null */ *zero(const FreeModule *F, const FreeModule *G);
 
@@ -137,6 +136,8 @@ class Matrix : public EngineObject
   static Matrix /* or null */ *flip(const FreeModule *G, const FreeModule *H);
 
   Matrix /* or null */ *direct_sum(const Matrix *m) const;
+  static const Matrix /* or null */ *direct_sum(unsigned int n,
+                                                const Matrix *const matrices[]);
   Matrix /* or null */ *module_tensor(const Matrix *m) const;
   Matrix /* or null */ *tensor(const Matrix *m) const;
   Matrix /* or null */ *diff(const Matrix *m, int use_coef) const;

--- a/M2/Macaulay2/e/matrix.hpp
+++ b/M2/Macaulay2/e/matrix.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 class MatrixConstructor;
+class RingElement;
 
 /**
  * \ingroup matrices
@@ -92,6 +93,7 @@ class Matrix : public EngineObject
   ring_elem elem(int i, int j) const;
   vec &elem(int i) { return mEntries[i]; }
   const vec &elem(int i) const { return mEntries[i]; }
+  const RingElement /* or null */ *entry(int r, int c) const;
   engine_RawRingElementArrayArrayOrNull entries() const;
   /*****************************************/
 

--- a/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
@@ -140,6 +140,50 @@ TEST(Matrix, entriesFromSparseColumns)
     }
 }
 
+TEST(Matrix, concatArray)
+{
+  const PolynomialRing* R = simplePolynomialRing(101, {"x", "y"});
+  const FreeModule* target = R->make_FreeModule(2);
+
+  MatrixConstructor left(target, 2);
+  left.set_entry(0, 0, R->from_long(2));
+  left.set_entry(1, 1, R->var(0));
+  left.compute_column_degrees();
+  const Matrix* A = left.to_matrix();
+
+  MatrixConstructor empty(target, 0);
+  const Matrix* E = empty.to_matrix();
+
+  MatrixConstructor right(target, 2);
+  right.set_entry(1, 0, R->from_long(5));
+  right.set_entry(0, 1, R->var(1));
+  right.compute_column_degrees();
+  const Matrix* B = right.to_matrix();
+
+  const Matrix* const matrices[] = {A, E, B};
+  const Matrix* C = Matrix::concat(3, matrices);
+
+  ASSERT_NE(C, nullptr);
+  EXPECT_EQ(C->rows(), target);
+  EXPECT_EQ(C->n_rows(), 2);
+  EXPECT_EQ(C->n_cols(), 4);
+
+  EXPECT_TRUE(R->is_equal(C->elem(0, 0), R->from_long(2)));
+  EXPECT_TRUE(R->is_zero(C->elem(1, 0)));
+  EXPECT_TRUE(R->is_zero(C->elem(0, 1)));
+  EXPECT_TRUE(R->is_equal(C->elem(1, 1), R->var(0)));
+  EXPECT_TRUE(R->is_zero(C->elem(0, 2)));
+  EXPECT_TRUE(R->is_equal(C->elem(1, 2), R->from_long(5)));
+  EXPECT_TRUE(R->is_equal(C->elem(0, 3), R->var(1)));
+  EXPECT_TRUE(R->is_zero(C->elem(1, 3)));
+
+  const Monoid* D = R->degree_monoid();
+  EXPECT_EQ(D->compare(C->cols()->degree(0), A->cols()->degree(0)), 0);
+  EXPECT_EQ(D->compare(C->cols()->degree(1), A->cols()->degree(1)), 0);
+  EXPECT_EQ(D->compare(C->cols()->degree(2), B->cols()->degree(0)), 0);
+  EXPECT_EQ(D->compare(C->cols()->degree(3), B->cols()->degree(1)), 0);
+}
+
 TEST(Matrix, promote)
 {
   const Ring* ZZ = globalZZ;

--- a/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
@@ -190,6 +190,50 @@ TEST(Matrix, promoteFailureReportsFirstEntry)
                "first error occurred while promoting matrix entry at row 2, column 0");
 }
 
+TEST(Matrix, liftFromPolynomialRingToCoefficientRing)
+{
+  const Ring* ZZ = globalZZ;
+  const PolynomialRing* P = degreeRing({"x"});
+
+  const FreeModule* polynomialTarget = P->make_FreeModule(3);
+  MatrixConstructor mat(polynomialTarget, 4);
+
+  mat.set_entry(0, 0, P->from_long(7));
+  mat.set_entry(2, 1, P->from_long(-3));
+  mat.set_entry(1, 3, P->from_long(11));
+  mat.compute_column_degrees();
+
+  const Matrix* M = mat.to_matrix();
+  const Matrix* lifted = M->lift(ZZ->make_FreeModule(3));
+
+  ASSERT_NE(lifted, nullptr);
+  EXPECT_EQ(lifted->get_ring(), ZZ);
+  EXPECT_EQ(lifted->n_rows(), 3);
+  EXPECT_EQ(lifted->n_cols(), 4);
+
+  EXPECT_TRUE(ZZ->is_equal(lifted->elem(0, 0), ZZ->from_long(7)));
+  EXPECT_TRUE(ZZ->is_equal(lifted->elem(2, 1), ZZ->from_long(-3)));
+  EXPECT_TRUE(ZZ->is_equal(lifted->elem(1, 3), ZZ->from_long(11)));
+  EXPECT_TRUE(ZZ->is_zero(lifted->elem(1, 1)));
+}
+
+TEST(Matrix, liftFailureReturnsNull)
+{
+  const Ring* ZZ = globalZZ;
+  const PolynomialRing* P = degreeRing({"x"});
+
+  const FreeModule* polynomialTarget = P->make_FreeModule(2);
+  MatrixConstructor mat(polynomialTarget, 1);
+  mat.set_entry(0, 0, P->var(0));
+  mat.compute_column_degrees();
+
+  const Matrix* M = mat.to_matrix();
+  EXPECT_EQ(M->lift(ZZ->make_FreeModule(2)), nullptr);
+  EXPECT_TRUE(error());
+  EXPECT_STREQ(error_message(),
+               "first error occurred while lifting matrix entry at row 0, column 0");
+}
+
 #if 0
 TEST(MatrixIO, readMsolveBig1)
 {

--- a/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
@@ -184,6 +184,87 @@ TEST(Matrix, concatArray)
   EXPECT_EQ(D->compare(C->cols()->degree(3), B->cols()->degree(1)), 0);
 }
 
+TEST(Matrix, directSum)
+{
+  const PolynomialRing* R = simplePolynomialRing(101, {"x", "y"});
+  const FreeModule* target = R->make_FreeModule(2);
+
+  MatrixConstructor left(target, 2);
+  left.set_entry(0, 0, R->from_long(2));
+  left.set_entry(1, 1, R->var(0));
+  left.compute_column_degrees();
+  const Matrix* A = left.to_matrix();
+
+  MatrixConstructor mid(target, 1);
+  mid.set_entry(0, 0, R->from_long(7));
+  mid.compute_column_degrees();
+  const Matrix* M = mid.to_matrix();
+
+  MatrixConstructor right(target, 2);
+  right.set_entry(1, 0, R->from_long(5));
+  right.set_entry(0, 1, R->var(1));
+  right.compute_column_degrees();
+  const Matrix* B = right.to_matrix();
+
+  const Matrix* const singleton[] = {A};
+  EXPECT_EQ(Matrix::direct_sum(1, singleton), A);
+
+  const Matrix* const matrices[] = {A, M, B};
+  const Matrix* C = Matrix::direct_sum(3, matrices);
+
+  ASSERT_NE(C, nullptr);
+  EXPECT_EQ(C->n_rows(), 6);
+  EXPECT_EQ(C->n_cols(), 5);
+
+  EXPECT_TRUE(R->is_equal(C->elem(0, 0), R->from_long(2))); // from A
+  EXPECT_TRUE(R->is_zero(C->elem(1, 0)));
+  EXPECT_TRUE(R->is_zero(C->elem(2, 0)));
+  EXPECT_TRUE(R->is_zero(C->elem(3, 0)));
+  EXPECT_TRUE(R->is_zero(C->elem(4, 0)));
+  EXPECT_TRUE(R->is_zero(C->elem(5, 0)));
+
+  EXPECT_TRUE(R->is_zero(C->elem(0, 1)));
+  EXPECT_TRUE(R->is_equal(C->elem(1, 1), R->var(0))); // from A
+  EXPECT_TRUE(R->is_zero(C->elem(2, 1)));
+  EXPECT_TRUE(R->is_zero(C->elem(3, 1)));
+  EXPECT_TRUE(R->is_zero(C->elem(4, 1)));
+  EXPECT_TRUE(R->is_zero(C->elem(5, 1)));
+
+  EXPECT_TRUE(R->is_zero(C->elem(0, 2)));
+  EXPECT_TRUE(R->is_zero(C->elem(1, 2)));
+  EXPECT_TRUE(R->is_equal(C->elem(2, 2), R->from_long(7))); // from M
+  EXPECT_TRUE(R->is_zero(C->elem(3, 2)));
+  EXPECT_TRUE(R->is_zero(C->elem(4, 2)));
+  EXPECT_TRUE(R->is_zero(C->elem(5, 2)));
+
+  EXPECT_TRUE(R->is_zero(C->elem(0, 3)));
+  EXPECT_TRUE(R->is_zero(C->elem(1, 3)));
+  EXPECT_TRUE(R->is_zero(C->elem(2, 3)));
+  EXPECT_TRUE(R->is_zero(C->elem(3, 3)));
+  EXPECT_TRUE(R->is_zero(C->elem(4, 3)));
+  EXPECT_TRUE(R->is_equal(C->elem(5, 3), R->from_long(5))); // from B
+
+  EXPECT_TRUE(R->is_zero(C->elem(0, 4)));
+  EXPECT_TRUE(R->is_zero(C->elem(1, 4)));
+  EXPECT_TRUE(R->is_zero(C->elem(2, 4)));
+  EXPECT_TRUE(R->is_zero(C->elem(3, 4)));
+  EXPECT_TRUE(R->is_equal(C->elem(4, 4), R->var(1))); // from B
+  EXPECT_TRUE(R->is_zero(C->elem(5, 4)));
+
+  const Monoid* D = R->degree_monoid();
+  EXPECT_EQ(D->compare(C->rows()->degree(0), A->rows()->degree(0)), 0);
+  EXPECT_EQ(D->compare(C->rows()->degree(1), A->rows()->degree(1)), 0);
+  EXPECT_EQ(D->compare(C->rows()->degree(2), M->rows()->degree(0)), 0);
+  EXPECT_EQ(D->compare(C->rows()->degree(3), M->rows()->degree(1)), 0);
+  EXPECT_EQ(D->compare(C->rows()->degree(4), B->rows()->degree(0)), 0);
+  EXPECT_EQ(D->compare(C->rows()->degree(5), B->rows()->degree(1)), 0);
+  EXPECT_EQ(D->compare(C->cols()->degree(0), A->cols()->degree(0)), 0);
+  EXPECT_EQ(D->compare(C->cols()->degree(1), A->cols()->degree(1)), 0);
+  EXPECT_EQ(D->compare(C->cols()->degree(2), M->cols()->degree(0)), 0);
+  EXPECT_EQ(D->compare(C->cols()->degree(3), B->cols()->degree(0)), 0);
+  EXPECT_EQ(D->compare(C->cols()->degree(4), B->cols()->degree(1)), 0);
+}
+
 TEST(Matrix, promote)
 {
   const Ring* ZZ = globalZZ;

--- a/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/MatrixIOTest.cpp
@@ -140,6 +140,35 @@ TEST(Matrix, entriesFromSparseColumns)
     }
 }
 
+TEST(Matrix, entry)
+{
+  const Ring* R = simplePolynomialRing(101, {"x"});
+  const FreeModule* target = R->make_FreeModule(3);
+  MatrixConstructor mat(target, 4);
+
+  mat.set_entry(1, 2, R->from_long(17));
+  mat.compute_column_degrees();
+
+  const Matrix* M = mat.to_matrix();
+  const RingElement* nonzero = M->entry(1, 2);
+  ASSERT_NE(nonzero, nullptr);
+  EXPECT_EQ(nonzero->get_ring(), R);
+  EXPECT_TRUE(R->is_equal(nonzero->get_value(), R->from_long(17)));
+
+  const RingElement* zero = M->entry(0, 0);
+  ASSERT_NE(zero, nullptr);
+  EXPECT_EQ(zero->get_ring(), R);
+  EXPECT_TRUE(R->is_zero(zero->get_value()));
+
+  EXPECT_EQ(M->entry(3, 0), nullptr);
+  EXPECT_TRUE(error());
+  EXPECT_STREQ(error_message(), "matrix row index 3 out of range 0 .. 2");
+
+  EXPECT_EQ(M->entry(0, 4), nullptr);
+  EXPECT_TRUE(error());
+  EXPECT_STREQ(error_message(), "matrix column index 4 out of range 0 .. 3");
+}
+
 TEST(Matrix, concatArray)
 {
   const PolynomialRing* R = simplePolynomialRing(101, {"x", "y"});

--- a/M2/Macaulay2/e/unit-tests/util-polyring-creation.cpp
+++ b/M2/Macaulay2/e/unit-tests/util-polyring-creation.cpp
@@ -67,13 +67,12 @@ const Monoid* simpleMonoid(const std::vector<std::string>& names,
   // #heft == #gens degreesRing.
   // heft of each degree vector for each vector should be > 0, if heft is non-empty.
 
-  const Monoid* M = Monoid::create(
-                             monorder,
-                             degRing,
-                             names,
-                             degs,
-                             heft
-                             );
+  return Monoid::create(
+      monorder,
+      degRing,
+      names,
+      degs,
+      heft);
 }
 
                            
@@ -174,15 +173,15 @@ const Matrix* idealFromStrings(const PolynomialRing* R,
 const Matrix* computeGB(const Matrix* M)
 {
   M2_arrayint weights = stdvector_to_M2_arrayint(std::vector<int>{});
-  Computation* C = IM2_GB_make(M,
-                               false,  // collect_syz
-                               0,      // n_rows_to_keep
-                               weights,
-                               false,  // use_max_degree
-                               0,      // max_degree
-                               0,      // algorithm (default)
-                               0,      // strategy (default)
-                               10);    // max_reduction_count (engine default)
+  Computation* C = rawGBMake(M,
+                             false,  // collect_syz
+                             0,      // n_rows_to_keep
+                             weights,
+                             false,  // use_max_degree
+                             0,      // max_degree
+                             0,      // algorithm (default)
+                             0,      // strategy (default)
+                             10);    // max_reduction_count (engine default)
   if (C == nullptr) return nullptr;
   rawStartComputation(C);
   return rawGBGetMatrix(C);


### PR DESCRIPTION
This PR completes all the push-down heavy logic of functions in interface/matrix.cpp to core, including
- rawMatrixLift 
- rawMatrixConcat 
- rawMatrixDirectSum (rewrite to optimize performance by avoiding repeated resource acquisition)
- rawMatrixEntry 


Flags some to-do function (untouched in this PR), with prefix `IM2`:
* IM2_Matrix_uniquify
* IM2_Matrix_min_leadterms
* IM2_Matrix_auto_reduce
* IM2_Matrix_reduce
* IM2_Matrix_reduce_by_ideal
* IM2_Matrix_dimension
* IM2_Matrix_remove_content

