### PR TITLE
Use some templates in aring-translate.hpp

### DIFF
--- a/M2/Macaulay2/e/basic-rings/aring-GF-flint-big.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-GF-flint-big.hpp
@@ -226,13 +226,6 @@ class ARingGFFlintBig : public RingInterface
     return true;
   }
 
-  bool set_from_BigReal(ElementType& result, gmp_RR a) const
-  {
-    (void) result;
-    (void) a;
-    return false;
-  }
-
   void negate(ElementType& result, const ElementType& a) const
   {
     fq_nmod_neg(&result, &a, mContext);

--- a/M2/Macaulay2/e/basic-rings/aring-GF-flint.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-GF-flint.hpp
@@ -207,13 +207,6 @@ class ARingGFFlint : public RingInterface
     return true;
   }
 
-  bool set_from_BigReal(ElementType& result, gmp_RR a) const
-  {
-    (void) result;
-    (void) a;
-    return false;
-  }
-
   void negate(ElementType& result, const ElementType& a) const
   {
     fq_zech_neg(&result, &a, mContext);

--- a/M2/Macaulay2/e/basic-rings/aring-QQ-flint.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-QQ-flint.hpp
@@ -116,13 +116,6 @@ class ARingQQFlint : public SimpleARing<ARingQQFlint>
     return true;
   }
 
-  bool set_from_BigReal(ElementType& result, gmp_RR a) const
-  {
-    (void) result;
-    (void) a;
-    return false;
-  }
-
   void set_var(ElementType& result, int v) const
   {
     (void) v;

--- a/M2/Macaulay2/e/basic-rings/aring-ZZ-flint.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZ-flint.hpp
@@ -111,13 +111,6 @@ void set_from_mpz(ElementType& result, mpz_srcptr a) const
     return false;
   }
 
-  bool set_from_BigReal(ElementType& result, gmp_RR a) const
-  {
-    (void) result;
-    (void) a;
-    return false;
-  }
-
   void set_var(ElementType& result, int v) const
   {
     (void) v;

--- a/M2/Macaulay2/e/basic-rings/aring-ZZp-ffpack.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZp-ffpack.hpp
@@ -160,13 +160,6 @@ class ARingZZpFFPACK : public SimpleARing<ARingZZpFFPACK>
 
   bool set_from_mpq(ElementType &result, mpq_srcptr a) const;
 
-  bool set_from_BigReal(ElementType &result, gmp_RR a) const
-  {
-    (void) result;
-    (void) a;
-    return false;
-  }
-
   ElementType computeGenerator() const;
 
   void set_var(ElementType &result, int v) const

--- a/M2/Macaulay2/e/basic-rings/aring-ZZp-flint.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZp-flint.hpp
@@ -119,13 +119,6 @@ class ARingZZpFlint : public SimpleARing<ARingZZpFlint>
     return true;
   }
 
-  bool set_from_BigReal(ElementType &result, gmp_RR a) const
-  {
-    (void) result;
-    (void) a;
-    return false;
-  }
-
   // arithmetic
   void negate(ElementType &result, ElementType a) const
   {

--- a/M2/Macaulay2/e/basic-rings/aring-ZZp.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZp.hpp
@@ -141,13 +141,6 @@ class ARingZZp : public SimpleARing<ARingZZp>
     return true;
   }
 
-  bool set_from_BigReal(elem &result, gmp_RR a) const
-  {
-    (void) result;
-    (void) a;
-    return false;
-  }
-
   // arithmetic
   void negate(elem &result, elem a) const
   {

--- a/M2/Macaulay2/e/basic-rings/aring-m2-GF.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-m2-GF.hpp
@@ -186,13 +186,6 @@ class ARingGFM2 : public SimpleARing<ARingGFM2>
     return true;
   }
 
-  bool set_from_BigReal(elem &result, gmp_RR a) const
-  {
-    (void) result;
-    (void) a;
-    return false;
-  }
-
   void negate(elem &result, elem a) const
   {
     if (a != 0)

--- a/M2/Macaulay2/e/basic-rings/aring-tower.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-tower.hpp
@@ -227,13 +227,6 @@ class ARingTower : public RingInterface
     return false;
   }  // TODO: write this
 
-  bool set_from_BigReal(elem &result, gmp_RR a) const
-  {
-    (void) result;
-    (void) a;
-    return false;
-  }
-
   // arithmetic
   void negate(elem &result, elem a) const
   {

--- a/M2/Macaulay2/e/basic-rings/aring-translate.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-translate.hpp
@@ -33,6 +33,16 @@ namespace M2 {
 
 namespace detail {
 template <typename RT, typename = void>
+inline constexpr bool has_set_from_double = false;
+
+template <typename RT>
+inline constexpr bool has_set_from_double<
+    RT,
+    std::void_t<decltype(std::declval<const RT&>().set_from_double(
+        std::declval<typename RT::ElementType&>(), std::declval<double>()))>> =
+    true;
+
+template <typename RT, typename = void>
 inline constexpr bool has_set_from_BigReal = false;
 
 template <typename RT>
@@ -42,6 +52,15 @@ inline constexpr bool has_set_from_BigReal<
         std::declval<typename RT::ElementType&>(), std::declval<gmp_RR>()))>> =
     true;
 }  // namespace detail
+
+template <typename RT>
+bool get_from_double(const RT& R, typename RT::ElementType& a, double b)
+{
+  if constexpr (detail::has_set_from_double<RT>)
+    return R.set_from_double(a, b);
+  else
+    return false;
+}
 
 template <typename RT>
 bool get_from_BigReal(const RT& R, typename RT::ElementType& a, gmp_RR b)
@@ -76,14 +95,6 @@ bool get_from_BigComplex(const RT& R, typename RT::ElementType& a, gmp_CC b)
   return false;
 }
 template <typename RT>
-bool get_from_double(const RT& R, typename RT::ElementType& a, double b)
-{
-  (void) R;
-  (void) a;
-  (void) b;
-  return false;
-}
-template <typename RT>
 bool get_from_complex_double(const RT& R,
                              typename RT::ElementType& a,
                              double re,
@@ -110,20 +121,6 @@ inline bool get_from_BigComplex(const ARingCC& R,
   return R.set_from_BigComplex(a, b);
 }
 
-inline bool get_from_double(const ARingRRR& R,
-                            ARingRRR::ElementType& a,
-                            double b)
-{
-  return R.set_from_double(a, b);
-}
-  
-inline bool get_from_double(const ARingRRi& R,
-                            ARingRRi::ElementType& a,
-                            double b)
-{
-   return R.set_from_double(a, b);
-}  
-    
 inline bool get_from_Interval(const ARingRRi& R,
                               ARingRRi::ElementType& a,
                               gmp_RRi b)
@@ -139,13 +136,6 @@ inline bool get_from_ComplexInterval(const ARingCCi& R,
     return true;
 }
 
-inline bool get_from_double(const ARingCCi& R,
-                            ARingCCi::ElementType& a,
-                            double b)
-{
-   return R.set_from_double(a, b);
-}
-
 inline bool get_from_Interval(const ARingCCi& R,
                               ARingCCi::ElementType& a,
                               gmp_RRi b)
@@ -158,23 +148,6 @@ inline bool get_from_BigComplex(const ARingCCi& R,
                                 gmp_CC b)
 {
   return R.set_from_BigComplex(a, b);
-}
-
-inline bool get_from_double(const ARingRR& R, ARingRR::ElementType& a, double b)
-{
-  return R.set_from_double(a, b);
-}
-
-inline bool get_from_double(const ARingCCC& R,
-                            ARingCCC::ElementType& a,
-                            double b)
-{
-  return R.set_from_double(a, b);
-}
-
-inline bool get_from_double(const ARingCC& R, ARingCC::ElementType& a, double b)
-{
-  return R.set_from_double(a, b);
 }
 
 inline bool get_from_complex_double(const ARingCCC& R,

--- a/M2/Macaulay2/e/basic-rings/aring-translate.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-translate.hpp
@@ -532,24 +532,11 @@ inline bool mylift(const ARingCC& R,
     
 /////////////////////////////////////////////////////
     
-inline bool mylift(const ARingRR& R,
-                    const ARingRRi& S,
-                    ARingRR::ElementType& result_gR,
-                    const ARingRRi::ElementType& gS)
-{
-    ARingRRR T(S.get_precision());
-    ARingRRR::Element gT(T);
-    auto gS1 = const_cast<ARingRRi::ElementType&>(gS);
-    S.midpoint(gT,gS1);
-    bool liftstep = mylift(R,T,result_gR,gT);
-    S.diameter(gT,gS1);
-    return liftstep && T.is_zero(gT);
-}
-
-inline bool mylift(const ARingRRR& R,
-                    const ARingRRi& S,
-                    ARingRRR::ElementType& result_gR,
-                    const ARingRRi::ElementType& gS)
+template <typename RingR>
+bool mylift(const RingR& R,
+            const ARingRRi& S,
+            typename RingR::ElementType& result_gR,
+            const ARingRRi::ElementType& gS)
 {
     ARingRRR T(S.get_precision());
     ARingRRR::Element gT(T);
@@ -576,20 +563,6 @@ inline bool mylift(const ARingQQ& R,
 {
   (void) S;
   return R.set_from_BigReal(fR, &fS);
-}
-
-inline bool mylift(const ARingQQ& R,
-                    const ARingRRi& S,
-                    ARingQQ::ElementType& result_gR,
-                    const ARingRRi::ElementType& gS)
-{
-    ARingRRR T(S.get_precision());
-    ARingRRR::Element gT(T);
-    auto gS1 = const_cast<ARingRRi::ElementType&>(gS);
-    S.midpoint(gT,gS1);
-    bool liftstep = mylift(R,T,result_gR,gT);
-    S.diameter(gT,gS1);
-    return liftstep && T.is_zero(gT);
 }
 
 // ZZ/p --> ZZ/p. 9 versions NONE OF THESE.

--- a/M2/Macaulay2/e/basic-rings/aring-translate.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-translate.hpp
@@ -53,6 +53,17 @@ inline constexpr bool has_set_from_BigReal<
     true;
 
 template <typename RT, typename = void>
+inline constexpr bool has_set_from_complex_double = false;
+
+template <typename RT>
+inline constexpr bool has_set_from_complex_double<
+    RT,
+    std::void_t<decltype(std::declval<const RT&>().set_from_complex_double(
+        std::declval<typename RT::ElementType&>(),
+        std::declval<double>(),
+        std::declval<double>()))>> = true;
+
+template <typename RT, typename = void>
 inline constexpr bool has_set_from_BigComplex = false;
 
 template <typename RT>
@@ -97,24 +108,24 @@ bool get_from_ComplexInterval(const RT& R, typename RT::ElementType & a, gmp_CCi
 }
 
 template <typename RT>
+bool get_from_complex_double(const RT& R,
+                             typename RT::ElementType& a,
+                             double re,
+                             double im)
+{
+  if constexpr (detail::has_set_from_complex_double<RT>)
+    return R.set_from_complex_double(a, re, im);
+  else
+    return false;
+}
+
+template <typename RT>
 bool get_from_BigComplex(const RT& R, typename RT::ElementType& a, gmp_CC b)
 {
   if constexpr (detail::has_set_from_BigComplex<RT>)
     return R.set_from_BigComplex(a, b);
   else
     return false;
-}
-template <typename RT>
-bool get_from_complex_double(const RT& R,
-                             typename RT::ElementType& a,
-                             double re,
-                             double im)
-{
-  (void) R;
-  (void) a;
-  (void) re;
-  (void) im;
-  return false;
 }
 
 inline bool get_from_Interval(const ARingRRi& R,
@@ -137,30 +148,6 @@ inline bool get_from_Interval(const ARingCCi& R,
                               gmp_RRi b)
 {
     return R.set_from_Interval(a, b);
-}
-
-inline bool get_from_complex_double(const ARingCCC& R,
-                                    ARingCCC::ElementType& a,
-                                    double re,
-                                    double im)
-{
-  return R.set_from_complex_double(a, re, im);
-}
-
-inline bool get_from_complex_double(const ARingCC& R,
-                                    ARingCC::ElementType& a,
-                                    double re,
-                                    double im)
-{
-  return R.set_from_complex_double(a, re, im);
-}
-
-inline bool get_from_complex_double(const ARingCCi& R,
-                                    ARingCCi::ElementType& a,
-                                    double re,
-                                    double im)
-{
-  return R.set_from_complex_double(a, re, im);
 }
 
 // Promote an element of one ring to another.

--- a/M2/Macaulay2/e/basic-rings/aring-translate.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-translate.hpp
@@ -53,6 +53,16 @@ inline constexpr bool has_set_from_BigReal<
     true;
 
 template <typename RT, typename = void>
+inline constexpr bool has_set_from_Interval = false;
+
+template <typename RT>
+inline constexpr bool has_set_from_Interval<
+    RT,
+    std::void_t<decltype(std::declval<const RT&>().set_from_Interval(
+        std::declval<typename RT::ElementType&>(), std::declval<gmp_RRi>()))>> =
+    true;
+
+template <typename RT, typename = void>
 inline constexpr bool has_set_from_complex_double = false;
 
 template <typename RT>
@@ -95,10 +105,10 @@ bool get_from_BigReal(const RT& R, typename RT::ElementType& a, gmp_RR b)
 template <typename RT>
 bool get_from_Interval(const RT& R, typename RT::ElementType& a, gmp_RRi b)
 {
-  (void) R;
-  (void) a;
-  (void) b;
-  return false;
+  if constexpr (detail::has_set_from_Interval<RT>)
+    return R.set_from_Interval(a, b);
+  else
+    return false;
 }
 
 template <typename RT>
@@ -128,26 +138,12 @@ bool get_from_BigComplex(const RT& R, typename RT::ElementType& a, gmp_CC b)
     return false;
 }
 
-inline bool get_from_Interval(const ARingRRi& R,
-                              ARingRRi::ElementType& a,
-                              gmp_RRi b)
-{
-    return R.set_from_Interval(a, b);
-}
-
 inline bool get_from_ComplexInterval(const ARingCCi& R,
                               ARingCCi::ElementType& a,
                               gmp_CCi b)
 {
     R.set(a, b);
     return true;
-}
-
-inline bool get_from_Interval(const ARingCCi& R,
-                              ARingCCi::ElementType& a,
-                              gmp_RRi b)
-{
-    return R.set_from_Interval(a, b);
 }
 
 // Promote an element of one ring to another.

--- a/M2/Macaulay2/e/basic-rings/aring-translate.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-translate.hpp
@@ -3,6 +3,9 @@
 #ifndef M2_BASIC_RINGS_ARING_TRANSLATE_HPP_
 #define M2_BASIC_RINGS_ARING_TRANSLATE_HPP_
 
+#include <type_traits>
+#include <utility>
+
 ///////////////////////////////////////////////////////
 // Contains functions which are "ring translational" //
 ///////////////////////////////////////////////////////
@@ -27,13 +30,26 @@
 #include "basic-rings/aring-GF-flint.hpp"
 
 namespace M2 {
+
+namespace detail {
+template <typename RT, typename = void>
+inline constexpr bool has_set_from_BigReal = false;
+
+template <typename RT>
+inline constexpr bool has_set_from_BigReal<
+    RT,
+    std::void_t<decltype(std::declval<const RT&>().set_from_BigReal(
+        std::declval<typename RT::ElementType&>(), std::declval<gmp_RR>()))>> =
+    true;
+}  // namespace detail
+
 template <typename RT>
 bool get_from_BigReal(const RT& R, typename RT::ElementType& a, gmp_RR b)
 {
-  (void) R;
-  (void) a;
-  (void) b;
-  return false;
+  if constexpr (detail::has_set_from_BigReal<RT>)
+    return R.set_from_BigReal(a, b);
+  else
+    return false;
 }
 
 template <typename RT>
@@ -78,48 +94,6 @@ bool get_from_complex_double(const RT& R,
   (void) re;
   (void) im;
   return false;
-}
-
-inline bool get_from_BigReal(const ARingQQ& R,
-                             ARingQQ::ElementType& a,
-                             gmp_RR b)
-{
-  return R.set_from_BigReal(a, b);
-}
-
-inline bool get_from_BigReal(const ARingRR& R,
-                             ARingRR::ElementType& a,
-                             gmp_RR b)
-{
-  return R.set_from_BigReal(a, b);
-}
-
-inline bool get_from_BigReal(const ARingRRR& R,
-                             ARingRRR::ElementType& a,
-                             gmp_RR b)
-{
-  return R.set_from_BigReal(a, b);
-}
-    
-inline bool get_from_BigReal(const ARingRRi& R,
-                             ARingRRi::ElementType& a,
-                             gmp_RR b)
-{
-    return R.set_from_BigReal(a, b);
-}
-
-inline bool get_from_BigReal(const ARingCC& R,
-                             ARingCC::ElementType& a,
-                             gmp_RR b)
-{
-  return R.set_from_BigReal(a, b);
-}
-
-inline bool get_from_BigReal(const ARingCCC& R,
-                             ARingCCC::ElementType& a,
-                             gmp_RR b)
-{
-  return R.set_from_BigReal(a, b);
 }
 
 inline bool get_from_BigComplex(const ARingCCC& R,
@@ -184,13 +158,6 @@ inline bool get_from_BigComplex(const ARingCCi& R,
                                 gmp_CC b)
 {
   return R.set_from_BigComplex(a, b);
-}
-
-inline bool get_from_BigReal(const ARingCCi& R,
-                             ARingCCi::ElementType& a,
-                             gmp_RR b)
-{
-  return R.set_from_BigReal(a, b);
 }
 
 inline bool get_from_double(const ARingRR& R, ARingRR::ElementType& a, double b)

--- a/M2/Macaulay2/e/basic-rings/aring-translate.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-translate.hpp
@@ -51,6 +51,16 @@ inline constexpr bool has_set_from_BigReal<
     std::void_t<decltype(std::declval<const RT&>().set_from_BigReal(
         std::declval<typename RT::ElementType&>(), std::declval<gmp_RR>()))>> =
     true;
+
+template <typename RT, typename = void>
+inline constexpr bool has_set_from_BigComplex = false;
+
+template <typename RT>
+inline constexpr bool has_set_from_BigComplex<
+    RT,
+    std::void_t<decltype(std::declval<const RT&>().set_from_BigComplex(
+        std::declval<typename RT::ElementType&>(), std::declval<gmp_CC>()))>> =
+    true;
 }  // namespace detail
 
 template <typename RT>
@@ -89,10 +99,10 @@ bool get_from_ComplexInterval(const RT& R, typename RT::ElementType & a, gmp_CCi
 template <typename RT>
 bool get_from_BigComplex(const RT& R, typename RT::ElementType& a, gmp_CC b)
 {
-  (void) R;
-  (void) a;
-  (void) b;
-  return false;
+  if constexpr (detail::has_set_from_BigComplex<RT>)
+    return R.set_from_BigComplex(a, b);
+  else
+    return false;
 }
 template <typename RT>
 bool get_from_complex_double(const RT& R,
@@ -105,20 +115,6 @@ bool get_from_complex_double(const RT& R,
   (void) re;
   (void) im;
   return false;
-}
-
-inline bool get_from_BigComplex(const ARingCCC& R,
-                                ARingCCC::ElementType& a,
-                                gmp_CC b)
-{
-  return R.set_from_BigComplex(a, b);
-}
-
-inline bool get_from_BigComplex(const ARingCC& R,
-                                ARingCC::ElementType& a,
-                                gmp_CC b)
-{
-  return R.set_from_BigComplex(a, b);
 }
 
 inline bool get_from_Interval(const ARingRRi& R,
@@ -141,13 +137,6 @@ inline bool get_from_Interval(const ARingCCi& R,
                               gmp_RRi b)
 {
     return R.set_from_Interval(a, b);
-}
-
-inline bool get_from_BigComplex(const ARingCCi& R,
-                                ARingCCi::ElementType& a,
-                                gmp_CC b)
-{
-  return R.set_from_BigComplex(a, b);
 }
 
 inline bool get_from_complex_double(const ARingCCC& R,

--- a/M2/Macaulay2/e/basic-rings/aring-translate.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-translate.hpp
@@ -82,6 +82,16 @@ inline constexpr bool has_set_from_BigComplex<
     std::void_t<decltype(std::declval<const RT&>().set_from_BigComplex(
         std::declval<typename RT::ElementType&>(), std::declval<gmp_CC>()))>> =
     true;
+
+template <typename RT, typename = void>
+inline constexpr bool has_set_from_ComplexInterval = false;
+
+template <typename RT>
+inline constexpr bool has_set_from_ComplexInterval<
+    RT,
+    std::void_t<decltype(std::declval<const RT&>().set_from_ComplexInterval(
+        std::declval<typename RT::ElementType&>(), std::declval<gmp_CCi>()))>> =
+    true;
 }  // namespace detail
 
 template <typename RT>
@@ -112,12 +122,6 @@ bool get_from_Interval(const RT& R, typename RT::ElementType& a, gmp_RRi b)
 }
 
 template <typename RT>
-bool get_from_ComplexInterval(const RT& R, typename RT::ElementType & a, gmp_CCi b)
-{
-    return false;
-}
-
-template <typename RT>
 bool get_from_complex_double(const RT& R,
                              typename RT::ElementType& a,
                              double re,
@@ -138,12 +142,13 @@ bool get_from_BigComplex(const RT& R, typename RT::ElementType& a, gmp_CC b)
     return false;
 }
 
-inline bool get_from_ComplexInterval(const ARingCCi& R,
-                              ARingCCi::ElementType& a,
-                              gmp_CCi b)
+template <typename RT>
+bool get_from_ComplexInterval(const RT& R, typename RT::ElementType & a, gmp_CCi b)
 {
-    R.set(a, b);
-    return true;
+  if constexpr (detail::has_set_from_ComplexInterval<RT>)
+    return R.set_from_ComplexInterval(a, b);
+  else
+    return false;
 }
 
 // Promote an element of one ring to another.

--- a/M2/Macaulay2/e/basic-rings/aring.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring.hpp
@@ -249,12 +249,6 @@ class DummyRing : public SimpleARing<DummyRing>
       (void) a;
       return false;
     }
-  bool set_from_BigReal(elem &result, gmp_RR a) const
-    {
-      (void) result;
-      (void) a;
-      return false;
-    }
   void set_var(elem &result, int v) const
     {
       (void) v;


### PR DESCRIPTION
Claude and I (mostly Claude...) added some templates in `aring-translate.hpp`.

Note that this is based on `development`, so we're pulling in lots of extra commits.

Here's Claude's overview:

## Summary

Simplify the "ring translation" glue in `M2/Macaulay2/e/basic-rings/aring-translate.hpp` by replacing per-ring boilerplate with compile-time dispatch.

### Background

The `ARing*` classes use a CRTP design (`SimpleARing<ARing>`), not virtual
dispatch. Historically, `aring-translate.hpp` provided generic
`get_from_BigReal`, `get_from_double`, `get_from_BigComplex`,
`get_from_complex_double`, `get_from_Interval`, and `get_from_ComplexInterval`
functions, each with a default that simply returned `false`. Every ring type
that *did* support one of these conversions then needed its own
`inline bool get_from_X(const ARingY&, ...)` overload, and every ring type
that *didn't* needed a `bool set_from_X(...) { return false; }` stub (with
`(void)` casts to silence unused-parameter warnings) just so the generic
function had something to call.

### What changed

For each of `BigReal`, `double`, `Interval`, `complex_double`, `BigComplex`,
and `ComplexInterval`, this branch:

1. Adds a SFINAE detection trait in a new `M2::detail` namespace, e.g.

   ```cpp
   template <typename RT, typename = void>
   inline constexpr bool has_set_from_BigReal = false;

   template <typename RT>
   inline constexpr bool has_set_from_BigReal<
       RT,
       std::void_t<decltype(std::declval<const RT&>().set_from_BigReal(
           std::declval<typename RT::ElementType&>(), std::declval<gmp_RR>()))>> =
       true;
   ```

2. Replaces the old generic `get_from_BigReal` (and the various
   per-ring overloads) with a single template that uses `if constexpr`:

   ```cpp
   template <typename RT>
   bool get_from_BigReal(const RT& R, typename RT::ElementType& a, gmp_RR b)
   {
     if constexpr (detail::has_set_from_BigReal<RT>)
       return R.set_from_BigReal(a, b);
     else
       return false;
   }
   ```

3. Removes the now-redundant `set_from_X(...) { return false; }` stubs from
   the 10 ring headers that had them (`aring-ZZ-flint.hpp`,
   `aring-GF-flint-big.hpp`, `aring-GF-flint.hpp`, `aring-ZZp-flint.hpp`,
   `aring-m2-GF.hpp`, `aring-QQ-flint.hpp`, `aring-ZZp-ffpack.hpp`,
   `aring-ZZp.hpp`, `aring-tower.hpp`, and `aring.hpp`'s `DummyRing`).

4. Removes the hand-written per-ring `get_from_X` overloads that are now
   subsumed by the generic template (e.g. the `ARingRRR`/`ARingCCC`/`ARingCC`/
   `ARingCCi`/`ARingRRi` overloads of `get_from_BigReal`, `get_from_BigComplex`,
   `get_from_complex_double`, `get_from_Interval`, `get_from_ComplexInterval`).

The traits and the corresponding `get_from_*` templates are both ordered
consistently: `double, BigReal, Interval, complex_double, BigComplex,
ComplexInterval` (real before complex, increasing order of complexity).

### Bug fix along the way

While doing this for `get_from_double`, it turned out that
`ARingQQGMP::set_from_double` already existed (added previously to support
`mylift(QQ, RR, ...)`), but `get_from_double` had no matching case for
`ARingQQGMP`, so `RingMap::eval`/`Ring::from_double` could not promote a
`double` coefficient into `QQ`. The generic SFINAE-based `get_from_double`
now picks this up automatically, so `RingMap`s sending `RR` coefficients to
`QQ` work correctly.

### `mylift`/`ARingRRi` cleanup

Separately, `mylift(R, S, ...)` had three overloads for `S = ARingRRi` (with
`R` = `ARingRR`, `ARingRRR`, `ARingQQ`) whose bodies were byte-for-byte
identical (compute the midpoint/diameter of the interval and recursively
`mylift` the midpoint, requiring the diameter to be zero). These are now a
single function template parameterized on `R`:

```cpp
template <typename RingR>
bool mylift(const RingR& R,
            const ARingRRi& S,
            typename RingR::ElementType& result_gR,
            const ARingRRi::ElementType& gS)
{
    ARingRRR T(S.get_precision());
    ARingRRR::Element gT(T);
    auto gS1 = const_cast<ARingRRi::ElementType&>(gS);
    S.midpoint(gT,gS1);
    bool liftstep = mylift(R,T,result_gR,gT);
    S.diameter(gT,gS1);
    return liftstep && T.is_zero(gT);
}
```

### Net effect

```
11 files changed, 96 insertions(+), 275 deletions(-)
```

mostly in `aring-translate.hpp`, with small deletions in the 10 ring headers
that no longer need `set_from_BigReal` stubs.

### Commits

- `8aa87ffde7` Use templates for get_from_BigReal
- `17236b4fb0` Use templates for get_from_double
- `4167958090` Use templates for get_from_BigComplex
- `6308802a3f` Use templates for get_from_complex_double
- `e20c140427` Use templates for get_from_Interval
- `74ba32c7cf` Use templates for get_from_ComplexInterval
- `6eea01736c` Use a single template for mylift(_, ARingRRi)
