### PR TITLE
Rename set_from_* methods to set

### DIFF
--- a/M2/Macaulay2/e/NAG/NAG.hpp
+++ b/M2/Macaulay2/e/NAG/NAG.hpp
@@ -149,7 +149,7 @@ inline const CCC* cast_to_CCC(const Ring* R)
 inline ring_elem from_doubles(const CCC* C, double re, double im)
 {
   M2::ARingCC::Element a(C->ring());
-  C->ring().set_from_doubles(a, re, im);
+  C->ring().set(a, re, im);
   ring_elem result;
   C->ring().to_ring_elem(result, a);
   return result;

--- a/M2/Macaulay2/e/SLP/SLP-imp.hpp
+++ b/M2/Macaulay2/e/SLP/SLP-imp.hpp
@@ -159,7 +159,7 @@ void SLEvaluatorConcrete<RT>::computeNextNode()
   switch (*nIt++)
     {
       case SLProgram::MProduct:
-        ring().set_from_long(v, 1);
+        ring().set(v, 1);
         for (int i = 0; i < *numInputsIt; i++)
           ring().mult(v, v, *(vIt + (*inputPositionsIt++)));
         numInputsIt++;
@@ -418,13 +418,13 @@ bool HomotopyConcrete<RT, FixedPrecisionHomotopyAlgorithm>::track(
   typedef MatElementaryOps<DMat<RT> > MatOps;
 
   RealElement t_step(R), min_step2(R), epsilon2(R), infinity_threshold2(R);
-  R.set_from_BigReal(t_step, init_dt);  // initial step
-  R.set_from_BigReal(min_step2, min_dt);
+  R.set(t_step, init_dt);  // initial step
+  R.set(min_step2, min_dt);
   R.mult(min_step2, min_step2, min_step2);  // min_step^2
-  R.set_from_BigReal(epsilon2, epsilon);
+  R.set(epsilon2, epsilon);
   int tolerance_bits = int(log2(fabs(R.coerceToDouble(epsilon2))));
   R.mult(epsilon2, epsilon2, epsilon2);  // epsilon^2
-  R.set_from_BigReal(infinity_threshold2, infinity_threshold);
+  R.set(infinity_threshold2, infinity_threshold);
   R.mult(infinity_threshold2, infinity_threshold2, infinity_threshold2);
   int num_successes_before_increase = 3;
 
@@ -433,10 +433,10 @@ bool HomotopyConcrete<RT, FixedPrecisionHomotopyAlgorithm>::track(
   // constants
   RealElement one(R), two(R), four(R), six(R), one_half(R), one_sixth(R);
   RealElementType& dt_factor = one_half;
-  R.set_from_long(one, 1);
-  R.set_from_long(two, 2);
-  R.set_from_long(four, 4);
-  R.set_from_long(six, 6);
+  R.set(one, 1);
+  R.set(two, 2);
+  R.set(four, 4);
+  R.set(six, 6);
   R.divide(one_half, one, two);
   R.divide(one_sixth, one, six);
 
@@ -749,8 +749,8 @@ bool HomotopyConcrete<RT, FixedPrecisionHomotopyAlgorithm>::track(
       for (size_t i = 0; i <= n; i++) C.set(ou.entry(i, s), x0c0.entry(i, 0));
       C.set(ou.entry(n + 1, s), dc);  // store last increment attempted
       if (status == PROCESSING) status = REGULAR;
-      oe.ring().set_from_long(oe.entry(0, s), status);
-      oe.ring().set_from_long(oe.entry(1, s), count);
+      oe.ring().set(oe.entry(0, s), status);
+      oe.ring().set(oe.entry(1, s), count);
     }
 
   std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();

--- a/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu-inplace.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu-inplace.hpp
@@ -161,7 +161,7 @@ inline size_t DMatLUinPlace<M2::ARingRRR>::findPivot(size_t row, size_t col)
       if (ring().compare_elems(abs, largest) > 0)
         {
           best_row_so_far = i;
-          ring().set(largest, abs);
+          ring().copy(largest, abs);
         }
     }
   return best_row_so_far;
@@ -392,10 +392,10 @@ void LUUtil<RingType>::setUpperLower(const Mat& LU, Mat& lower, Mat& upper)
       for (size_t r = 0; r < LU.numRows(); r++)
         {
           if (r <= c)
-            LU.ring().set(upper.entry(r, c), LU.entry(r, c));
+            LU.ring().copy(upper.entry(r, c), LU.entry(r, c));
           else if (c < lower.numRows())
             {
-              LU.ring().set(lower.entry(r, c), LU.entry(r, c));
+              LU.ring().copy(lower.entry(r, c), LU.entry(r, c));
             }
         }
     }

--- a/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu-inplace.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu-inplace.hpp
@@ -388,7 +388,7 @@ void LUUtil<RingType>::setUpperLower(const Mat& LU, Mat& lower, Mat& upper)
 
   for (size_t c = 0; c < LU.numColumns(); c++)
     {
-      if (c < min) LU.ring().set_from_long(lower.entry(c, c), 1);
+      if (c < min) LU.ring().set(lower.entry(c, c), 1);
       for (size_t r = 0; r < LU.numRows(); r++)
         {
           if (r <= c)

--- a/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu-qq.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu-qq.hpp
@@ -119,7 +119,7 @@ class DMatLinAlg<M2::ARingQQ>
 //     fmpq_init(b);
 //     for (size_t c = 0; c < LU.numColumns(); c++)
 //       {
-//         if (c < min) L.ring().set_from_long(L.entry(c, c), 1);
+//         if (c < min) L.ring().set(L.entry(c, c), 1);
 //         for (size_t r = 0; r < LU.numRows(); r++)
 //           {
 //             if (r <= c)
@@ -131,8 +131,8 @@ class DMatLinAlg<M2::ARingQQ>
 
 //                 fmpq_set_fmpz_frac(b, fmpz_mat_entry(LU.value(), r, c), den);
 //                 flint_mpq_init_set_readonly(a, b);
-//                 assert(U.ring().set_from_mpq(U.entry(r, c), a));
-//                 U.ring().set_from_mpq(U.entry(r, c), a);  // ignore the result
+//                 assert(U.ring().set(U.entry(r, c), a));
+//                 U.ring().set(U.entry(r, c), a);  // ignore the result
 //                                                           // boolean: this
 //                                                           // operation should
 //                                                           // not fail
@@ -143,7 +143,7 @@ class DMatLinAlg<M2::ARingQQ>
 //                 mpz_t a;
 //                 flint_mpz_init_set_readonly(a,
 //                                             fmpz_mat_entry(LU.value(), r, c));
-//                 L.ring().set_from_mpz(L.entry(r, c), a);
+//                 L.ring().set(L.entry(r, c), a);
 //                 flint_mpz_clear_readonly(a);
 //               }
 //           }

--- a/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu-zzp-flint.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu-zzp-flint.hpp
@@ -80,7 +80,7 @@ class DMatLinAlg<M2::ARingZZpFlint>
         // Fill in this column
         for (long r = 0; r < profile.size(); r++)
           {
-            mMatrix.ring().set(X.entry(profile[r], c), AB.entry(r, ncols + c));
+            mMatrix.ring().copy(X.entry(profile[r], c), AB.entry(r, ncols + c));
           }
       }
     return true;

--- a/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu.hpp
@@ -219,7 +219,7 @@ void DMatLinAlg<RingType>::setUpperLower(const Mat& LU, Mat& lower, Mat& upper)
 
       if (c < lower.numColumns())
         {
-          lower.ring().set_from_long(*L, 1); // diagonal entry of L should be 1
+          lower.ring().set(*L, 1); // diagonal entry of L should be 1
           L += lower.numColumns(); // pointing to entry right below diagonal
           auto L1 = L; // will increment by lower.numRows() each loop here
           for (size_t r=c+1; r<lower.numRows(); r++)
@@ -245,7 +245,7 @@ void DMatLinAlg<RingType>::setUpperLower(const Mat& LU, Mat& lower, Mat& upper)
 
   for (size_t c = 0; c < LU.numColumns(); c++)
     {
-      if (c < min) ring().set_from_long(lower.entry(c, c), 1);
+      if (c < min) ring().set(lower.entry(c, c), 1);
       for (size_t r = 0; r < LU.numRows(); r++)
         {
           if (r <= c)
@@ -278,9 +278,9 @@ void DMatLinAlg<RingType>::determinant(ElementType& result)
   assert(LU.numRows() == LU.numColumns());
 
   if (mLUObject.signOfPermutation())
-    ring().set_from_long(result, 1);
+    ring().set(result, 1);
   else
-    ring().set_from_long(result, -1);
+    ring().set(result, -1);
   for (size_t i = 0; i < LU.numRows(); i++)
     ring().mult(result, result, LU.entry(i, i));
 }
@@ -535,7 +535,7 @@ bool DMatLinAlg<RingType>::inverse(Mat& X)
 
   Mat id(ring(), LU.numRows(), LU.numRows());
   for (size_t i = 0; i < LU.numRows(); i++)
-    ring().set_from_long(id.entry(i, i), 1);
+    ring().set(id.entry(i, i), 1);
 
   solve(id, X);
   return true;
@@ -569,7 +569,7 @@ size_t DMatLinAlg<RingType>::kernel(Mat& X)
           continue;
         }
       // At this point, we are ready to create a column of X.
-      ring().set_from_long(X.entry(col, colX), -1);
+      ring().set(X.entry(col, colX), -1);
       // Now we loop through and set the elements in the rows of X = pivot
       // columns.
       for (long p = nextpivotidx - 1; p >= 0; p--)

--- a/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/dmat-lu.hpp
@@ -212,7 +212,7 @@ void DMatLinAlg<RingType>::setUpperLower(const Mat& LU, Mat& lower, Mat& upper)
       for (size_t r=0; r<=c; r++)
         {
           if (r >= upper.numRows()) break;
-          upper.ring().set(*U1, *LUraw++);
+          upper.ring().copy(*U1, *LUraw++);
           U1 += upper.numColumns();
         }
       U++; // change to next column
@@ -224,7 +224,7 @@ void DMatLinAlg<RingType>::setUpperLower(const Mat& LU, Mat& lower, Mat& upper)
           auto L1 = L; // will increment by lower.numRows() each loop here
           for (size_t r=c+1; r<lower.numRows(); r++)
             {
-              lower.ring().set(*L1, *LUraw++);
+              lower.ring().copy(*L1, *LUraw++);
               L1 += lower.numColumns(); // to place next entry.
             }
           L++; // change to next column
@@ -249,10 +249,10 @@ void DMatLinAlg<RingType>::setUpperLower(const Mat& LU, Mat& lower, Mat& upper)
       for (size_t r = 0; r < LU.numRows(); r++)
         {
           if (r <= c)
-            ring().set(upper.entry(r, c), LU.entry(r, c));
+            ring().copy(upper.entry(r, c), LU.entry(r, c));
           else if (c < lower.numRows())
             {
-              ring().set(lower.entry(r, c), LU.entry(r, c));
+              ring().copy(lower.entry(r, c), LU.entry(r, c));
             }
         }
     }
@@ -345,7 +345,7 @@ bool DMatLinAlg<RingType>::solve(const Mat& B, Mat& X)
 
       // Step 1: set b to be the permuted i-th column of B.
       for (size_t r = 0; r < B.numRows(); r++)
-        ring().set(b[r], B.entry(perm[r], col));
+        ring().copy(b[r], B.entry(perm[r], col));
 
       /// printf("b:\n");
       /// debug_out_list(b, LU.numRows());
@@ -353,7 +353,7 @@ bool DMatLinAlg<RingType>::solve(const Mat& B, Mat& X)
       // Step 2: Solve Ly=b
       for (size_t i = 0; i < rk; i++)
         {
-          ring().set(y[i], b[i]);
+          ring().copy(y[i], b[i]);
           for (size_t j = 0; j < i; j++)
             {
               ring().mult(tmp, LU.entry(i, j), y[j]);
@@ -367,7 +367,7 @@ bool DMatLinAlg<RingType>::solve(const Mat& B, Mat& X)
       // Step 2B: see if the solution is consistent
       for (size_t i = rk; i < LU.numRows(); i++)
         {
-          ring().set(tmp, b[i]);
+          ring().copy(tmp.value(), b[i]);
           for (size_t j = 0; j < rk; j++)
             {
               ring().mult(tmp2, LU.entry(i, j), y[j]);
@@ -386,14 +386,14 @@ bool DMatLinAlg<RingType>::solve(const Mat& B, Mat& X)
       // and place x back into X as col-th column
       for (long i = rk - 1; i >= 0; --i)
         {
-          ring().set(x[i], y[i]);
+          ring().copy(x[i], y[i]);
           for (size_t j = i + 1; j <= rk - 1; j++)
             {
               ring().mult(tmp, LU.entry(i, pivotColumns[j]), x[j]);
               ring().subtract(x[i], x[i], tmp);
             }
           ring().divide(x[i], x[i], LU.entry(i, pivotColumns[i]));
-          ring().set(X.entry(pivotColumns[i], col), x[i]);
+          ring().copy(X.entry(pivotColumns[i], col), x[i]);
 
           /// buffer o;
           /// printf("after i=%ld\n", i);
@@ -436,7 +436,7 @@ void permuteRows(const Mat& B,
                 B.numColumns());  // leaves B alone if correct size already...
   for (long r = 0; r < B.numRows(); r++)
     for (long c = 0; c < B.numColumns(); c++)
-      B.ring().set(result.entry(r, c), B.entry(permutation[r], c));
+      B.ring().copy(result.entry(r, c), B.entry(permutation[r], c));
 }
 
 template <class Mat>
@@ -575,7 +575,7 @@ size_t DMatLinAlg<RingType>::kernel(Mat& X)
       for (long p = nextpivotidx - 1; p >= 0; p--)
         {
           // set X.entry(pivotColumns[p], colX)
-          ring().set(tmp, LU.entry(p, col));
+          ring().copy(tmp.value(), LU.entry(p, col));
           for (size_t i = nextpivotidx - 1; i >= p + 1; i--)
             {
               ring().mult(tmp2,
@@ -584,7 +584,7 @@ size_t DMatLinAlg<RingType>::kernel(Mat& X)
               ring().subtract(tmp, tmp, tmp2);
             }
           ring().divide(tmp, tmp, LU.entry(p, pivotColumns[p]));
-          ring().set(X.entry(pivotColumns[p], colX), tmp);
+          ring().copy(X.entry(pivotColumns[p], colX), tmp.value());
         }
       colX++;
       col++;

--- a/M2/Macaulay2/e/basic-mutable-matrices/dmat.cpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/dmat.cpp
@@ -33,7 +33,7 @@ void addMultipleTo(DMatZZpFFPACK& C,
 
   DMatZZpFFPACK::ElementType b;
   C.ring().init(b);
-  C.ring().set_from_long(b, 1);
+  C.ring().set(b, 1);
   FFLAS::fgemm(C.ring().field(),
                tB,
                tA,
@@ -55,7 +55,7 @@ void addMultipleTo(DMatZZpFFPACK& C,
                    const DMatZZpFFPACK& B)
 {
   DMatZZpFFPACK::ElementType one;
-  A.ring().set_from_long(one, 1);
+  A.ring().set(one, 1);
 
   addMultipleTo(C, one, A, B);
 }
@@ -65,7 +65,7 @@ void subtractMultipleTo(DMatZZpFFPACK& C,
                         const DMatZZpFFPACK& B)
 {
   DMatZZpFFPACK::ElementType minus_one;
-  A.ring().set_from_long(minus_one, -1);
+  A.ring().set(minus_one, -1);
   addMultipleTo(C, minus_one, A, B);
 }
 
@@ -96,7 +96,7 @@ void determinant(const DMatZZpFFPACK& mat, ZZpFFPACK::ElementType& result_det)
     {
       // 26 April 2014: this branch is needed as FFPACK gives answer of 0 in
       // this case.
-      mat.ring().set_from_long(result_det, 1);
+      mat.ring().set(result_det, 1);
     }
   else
     {

--- a/M2/Macaulay2/e/basic-mutable-matrices/lapack.cpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/lapack.cpp
@@ -119,7 +119,7 @@ void fill_from_lapack_upper(const std::vector<double>& lapack_numbers,  // colum
     for (size_t r = 0; r <= c; ++r)
       {
         if (r >= upper.numRows()) break;
-        upper.ring().set_from_doubles(upper.entry(r, c), U[2*r], U[2*r+1]);
+        upper.ring().set(upper.entry(r, c), U[2*r], U[2*r+1]);
       }
 }
 
@@ -176,16 +176,16 @@ void fill_lower_and_upper(const std::vector<double>& lapack_numbers,  // column-
         {
           double re = *U++;
           double im = *U++;
-          ring.set_from_doubles(upper.entry(r, c), re, im);
+          ring.set(upper.entry(r, c), re, im);
           // upper.entry(r, c).re = *U++;
           // upper.entry(r, c).im = *U++;
         }
-      ring.set_from_long(lower.entry(c, c), 1);
+      ring.set(lower.entry(c, c), 1);
       for (size_t r = c+1 ; r <= lower.numColumns(); ++r)
         {
           double re = *U++;
           double im = *U++;
-          ring.set_from_doubles(lower.entry(r, c), re, im);
+          ring.set(lower.entry(r, c), re, im);
           // lower.entry(r,c).re = *U++;
           // lower.entry(r,c).im = *U++;
         }
@@ -353,7 +353,7 @@ bool Lapack::eigenvalues(const DMatRR *A, DMatCC *eigvals)
     {
       eigvals->resize(size, 1);
       for (int i = 0; i < size; i++)
-        eigvals->ring().set_from_doubles(eigvals->entry(i, 0), real[i], imag[i]);
+        eigvals->ring().set(eigvals->entry(i, 0), real[i], imag[i]);
     }
 
   delete [] real;
@@ -427,7 +427,7 @@ bool Lapack::eigenvectors(const DMatRR *A,
       double* eigenLoc = eigen; // current row (eigenvector) in the eigen array
       for (int j = 0; j < size; j++, eigenLoc += size)
         {
-          eigvals->ring().set_from_doubles(eigvals->entry(j,0), real[j], imag[j]);
+          eigvals->ring().set(eigvals->entry(j,0), real[j], imag[j]);
 
           // now set j-th column of eigvecs
           if (imag[j] == 0)
@@ -442,9 +442,9 @@ bool Lapack::eigenvectors(const DMatRR *A,
             {
               for (int i = 0; i < size; ++i)
                 {
-                  eigvecs->ring().set_from_doubles(eigvecs->entry(i,j),
+                  eigvecs->ring().set(eigvecs->entry(i,j),
                                                    eigenLoc[i], eigenLoc[size + i]);
-                  eigvecs->ring().set_from_doubles(eigvecs->entry(i,j+1),
+                  eigvecs->ring().set(eigvecs->entry(i,j+1),
                                                    eigenLoc[i], - eigenLoc[size + i]);
                 }
             }
@@ -1710,7 +1710,7 @@ bool Lapack::least_squares(const DMatCC *A, const DMatCC *b, DMatCC *x)
                 {
                   double re = copyb[copyloc++];
                   double im = copyb[copyloc++];
-                  x->ring().set_from_doubles(x->entry(i,j), re, im);
+                  x->ring().set(x->entry(i,j), re, im);
                 }
             }
         }
@@ -1811,7 +1811,7 @@ bool Lapack::least_squares_deficient(const DMatCC *A,
                 {
                   double re = copyb[copyloc++];
                   double im = copyb[copyloc++];
-                  x->ring().set_from_doubles(x->entry(i,j), re, im);
+                  x->ring().set(x->entry(i,j), re, im);
                 }
             }
         }

--- a/M2/Macaulay2/e/basic-mutable-matrices/mat-arith.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/mat-arith.hpp
@@ -83,7 +83,7 @@ struct SubMatrix
         long cA = begin_column;
         long cB = src.begin_column;
         for (; cA < end_column; ++cA, ++cB)
-          matrix.ring().set(matrix.entry(rA, cA), src.matrix.entry(rB, cB));
+          matrix.ring().copy(matrix.entry(rA, cA), src.matrix.entry(rB, cB));
       }
   }
 
@@ -236,7 +236,7 @@ void transpose(const DMat<RT>& A, DMat<RT>& result)
 
   for (int r = 0; r < A.numRows(); ++r)
     for (int c = 0; c < A.numColumns(); ++c)
-      A.ring().set(result.entry(c,r), A.entry(r,c));
+      A.ring().copy(result.entry(c,r), A.entry(r,c));
 }
 
 //  wA = 0
@@ -269,7 +269,7 @@ void set(DMat<RT>& A, MatrixWindow wA, const DMat<RT>& B, MatrixWindow wB)
       long cA = wA.begin_column;
       long cB = wB.begin_column;
       for (; cA < wA.end_column; ++cA, ++cB)
-        A.ring().set(A.entry(rA, cA), B.entry(rB, cB));
+        A.ring().copy(A.entry(rA, cA), B.entry(rB, cB));
     }
 }
 

--- a/M2/Macaulay2/e/basic-mutable-matrices/mat-elem-ops.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/mat-elem-ops.hpp
@@ -54,7 +54,7 @@ class MatElementaryOps<DMat<RT> >
         --row;
         if (!mat.ring().is_zero(mat.entry(row, col)))
           {
-            mat.ring().set(result, mat.entry(row, col));
+            mat.ring().copy(result, mat.entry(row, col));
             return row;
           }
       }
@@ -192,8 +192,8 @@ class MatElementaryOps<DMat<RT> >
         ring.mult(g2, b2, mat.entry(r2,c));
         ring.add(g1, g1, g2);
 
-        ring.set(mat.entry(r1,c), f1);
-        ring.set(mat.entry(r2,c), g1);
+        ring.copy(mat.entry(r1,c), f1.value());
+        ring.copy(mat.entry(r2,c), g1.value());
       }
   }
 
@@ -229,8 +229,8 @@ class MatElementaryOps<DMat<RT> >
         ring.mult(g2, b2, mat.entry(r, c2));
         ring.add(g1, g1, g2);
 
-        ring.set(mat.entry(r, c1), f1);
-        ring.set(mat.entry(r, c2), g1);
+        ring.copy(mat.entry(r, c1), f1.value());
+        ring.copy(mat.entry(r, c2), g1.value());
       }
   }
 
@@ -556,7 +556,7 @@ class MatElementaryOps<DMat<RT> >
     // assert(c1-c0+1<=result.numColumns());
     for (size_t r = r0; r <= r1; r++)
       for (size_t c = c0; c <= c1; c++)
-        mat.ring().set(result.entry(r - r0, c - c0), mat.entry(r, c));
+        mat.ring().copy(result.entry(r - r0, c - c0), mat.entry(r, c));
   }
 
   static void setFromSubmatrix(const Mat& mat,
@@ -569,8 +569,8 @@ class MatElementaryOps<DMat<RT> >
     result.resize(rows->len, cols->len);  // resets to a zero matrix
     for (size_t r = 0; r < rows->len; r++)
       for (size_t c = 0; c < cols->len; c++)
-        mat.ring().set(result.entry(r, c),
-                       mat.entry(rows->array[r], cols->array[c]));
+        mat.ring().copy(result.entry(r, c),
+                        mat.entry(rows->array[r], cols->array[c]));
   }
 
   static void setFromSubmatrix(const Mat& mat, M2_arrayint cols, Mat& result)
@@ -580,17 +580,17 @@ class MatElementaryOps<DMat<RT> >
     result.resize(mat.numRows(), cols->len);  // resets to a zero matrix
     for (size_t r = 0; r < mat.numRows(); r++)
       for (size_t c = 0; c < cols->len; c++)
-        mat.ring().set(result.entry(r, c), mat.entry(r, cols->array[c]));
+        mat.ring().copy(result.entry(r, c), mat.entry(r, cols->array[c]));
   }
 
   static void getEntry(const Mat& mat, size_t r, size_t c, ElementType& result)
   {
-    mat.ring().set(result, mat.entry(r, c));
+    mat.ring().copy(result, mat.entry(r, c));
   }
 
   static void setEntry(Mat& mat, size_t r, size_t c, const ElementType& a)
   {
-    mat.ring().set(mat.entry(r, c), a);
+    mat.ring().copy(mat.entry(r, c), a);
   }
 
  private:

--- a/M2/Macaulay2/e/basic-mutable-matrices/mat-elem-ops.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/mat-elem-ops.hpp
@@ -446,8 +446,8 @@ class MatElementaryOps<DMat<RT> >
 
     Element pivot(M.ring()), coef(M.ring()), f(M.ring()), zero(M.ring()),
         one(M.ring());
-    M.ring().set_from_long(zero, 0);
-    M.ring().set_from_long(one, 1);
+    M.ring().set(zero, 0);
+    M.ring().set(one, 1);
 
     interchange_columns(M, c, nc);
     interchange_rows(M, r, nr);
@@ -480,8 +480,8 @@ class MatElementaryOps<DMat<RT> >
     size_t nc = M.numColumns() - 1;
 
     Element one(M.ring()), minus_one(M.ring());
-    M.ring().set_from_long(one, 1);
-    M.ring().set_from_long(minus_one, -1);
+    M.ring().set(one, 1);
+    M.ring().set(minus_one, -1);
 
     // After using the pivot element, it is moved to [nrows-1,ncols-1]
     // and nrows and ncols are decremented.

--- a/M2/Macaulay2/e/basic-mutable-matrices/mat-util.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/mat-util.hpp
@@ -64,10 +64,10 @@ static void concatenateMatrices(const Mat& A, const Mat& B, Mat& C)
   C.resize(A.numRows(), A.numColumns() + B.numColumns());
   for (long r = 0; r < A.numRows(); r++)
     for (long c = 0; c < A.numColumns(); c++)
-      A.ring().set(C.entry(r, c), A.entry(r, c));
+      A.ring().copy(C.entry(r, c), A.entry(r, c));
   for (long r = 0; r < A.numRows(); r++)
     for (long c = 0; c < B.numColumns(); c++)
-      A.ring().set(C.entry(r, c + A.numColumns()), B.entry(r, c));
+      A.ring().copy(C.entry(r, c + A.numColumns()), B.entry(r, c));
 }
 
 #endif

--- a/M2/Macaulay2/e/basic-mutable-matrices/smat.hpp
+++ b/M2/Macaulay2/e/basic-mutable-matrices/smat.hpp
@@ -310,7 +310,7 @@ bool SMat<CoeffRing>::vec_get_entry(const sparsevec *v,
       break;
     else if (p->row == r)
       {
-        ring().set(result, p->coeff);
+        ring().copy(result, p->coeff);
         return true;
       }
   return false;
@@ -347,7 +347,7 @@ void SMat<CoeffRing>::vec_set_entry(sparsevec *&v,
           vec_remove_node(tmp);
         }
       else
-        ring().set(p->next->coeff, a);
+        ring().copy(p->next->coeff, a);
     }
   v = head.next;
 }

--- a/M2/Macaulay2/e/basic-rings/aring-CC.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-CC.hpp
@@ -120,62 +120,56 @@ class ARingCC : public SimpleARing<ARingCC>
   }
 
   void copy(ElementType& result, const ElementType& a) const { set(result, a); }
-  void set_from_long(ElementType& result, long a) const
+  void set(ElementType& result, long a) const
   {
     result.re = static_cast<double>(a);
     result.im = 0.0;
   }
+  void set(ElementType& result, int a) const { set(result, (long)a); }
 
   void set_var(ElementType& result, int v) const
   {
     (void) v;
-    set_from_long(result, 1);
+    set(result, 1);
   }
 
-  void set_from_mpz(ElementType& result, mpz_srcptr a) const
+  void set(ElementType& result, mpz_srcptr a) const
   {
     result.re = mpz_get_d(a);
     result.im = 0.0;
   }
 
-  bool set_from_mpq(ElementType& result, mpq_srcptr a) const
+  bool set(ElementType& result, mpq_srcptr a) const
   {
     result.re = mpq_get_d(a);
     result.im = 0.0;
     return true;
   }
 
-  bool set_from_BigReal(ElementType& result, gmp_RR a) const
+  bool set(ElementType& result, gmp_RR a) const
   {
     result.re = mpfr_get_d(a, MPFR_RNDN);
     result.im = 0.0;
     return true;
   }
-  bool set_from_BigReals(ElementType& result, gmp_RR re, gmp_RR im) const
+  bool set(ElementType& result, gmp_RR re, gmp_RR im) const
   {
     result.re = mpfr_get_d(re, MPFR_RNDN);
     result.im = mpfr_get_d(im, MPFR_RNDN);
     return true;
   }
-  bool set_from_BigComplex(ElementType& result, gmp_CC a) const
+  bool set(ElementType& result, gmp_CC a) const
   {
     result.re = mpfr_get_d(a->re, MPFR_RNDN);
     result.im = mpfr_get_d(a->im, MPFR_RNDN);
     return true;
   }
-  bool set_from_double(ElementType& result, double a) const
+  bool set(ElementType& result, double a) const
   {
     result.re = a;
     result.im = 0;
     return true;
   }
-  bool set_from_complex_double(ElementType& result, double re, double im) const
-  {
-    result.re = re;
-    result.im = im;
-    return true;
-  }
-
   // arithmetic
   void negate(ElementType& result, const ElementType& a) const
   {
@@ -314,7 +308,7 @@ class ARingCC : public SimpleARing<ARingCC>
   {
     ElementType curr_pow;
     init(curr_pow);
-    set_from_long(result, 1);
+    set(result, 1);
     if (n == 0)
       {
       }
@@ -404,7 +398,7 @@ class ARingCC : public SimpleARing<ARingCC>
     return moveTo_gmpCC(result);
   }
 
-  void set_from_doubles(ElementType& result, double re, double im) const
+  void set(ElementType& result, double re, double im) const
   {
     result.re = re;
     result.im = im;

--- a/M2/Macaulay2/e/basic-rings/aring-CCC.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-CCC.hpp
@@ -131,62 +131,50 @@ class ARingCCC : public SimpleARing<ARingCCC>
   }
 
   void copy(ElementType& result, const ElementType& a) const { set(result, a); }
-  void set_from_long(ElementType& result, long a) const
+  void set(ElementType& result, long a) const
   {
     mpfr_set_si(&result.re, a, MPFR_RNDN);
     mpfr_set_si(&result.im, 0, MPFR_RNDN);
   }
+  void set(ElementType& result, int a) const { set(result, (long)a); }
 
   void set_var(ElementType& result, int v) const
   {
     (void) v;
-    set_from_long(result, 1);
+    set(result, 1);
   }
 
-  void set_from_mpz(ElementType& result, mpz_srcptr a) const
+  void set(ElementType& result, mpz_srcptr a) const
   {
     mpfr_set_z(&result.re, a, MPFR_RNDN);
     mpfr_set_si(&result.im, 0, MPFR_RNDN);
   }
 
-  bool set_from_mpq(ElementType& result, mpq_srcptr a) const
+  bool set(ElementType& result, mpq_srcptr a) const
   {
     mpfr_set_q(&result.re, a, MPFR_RNDN);
     mpfr_set_si(&result.im, 0, MPFR_RNDN);
     return true;
   }
 
-  bool set_from_BigReal(ElementType& result, gmp_RR a) const
+  bool set(ElementType& result, gmp_RR a) const
   {
     mpfr_set(&result.re, a, MPFR_RNDN);
     mpfr_set_si(&result.im, 0, MPFR_RNDN);
     return true;
   }
-  bool set_from_BigComplex(ElementType& result, gmp_CC a) const
+  bool set(ElementType& result, gmp_CC a) const
   {  //???
     mpfr_set(&result.re, a->re, MPFR_RNDN);
     mpfr_set(&result.im, a->im, MPFR_RNDN);
     return true;
   }
-  bool set_from_double(ElementType& result, double a) const
+  bool set(ElementType& result, double a) const
   {
     mpfr_set_d(&result.re, a, MPFR_RNDN);
     mpfr_set_si(&result.im, 0, MPFR_RNDN);
     return true;
   }
-  bool set_from_complex_double(ElementType& result, double re, double im) const
-  {
-    mpfr_set_d(&result.re, re, MPFR_RNDN);
-    mpfr_set_d(&result.im, im, MPFR_RNDN);
-    return true;
-  }
-  bool set_from_complex_mpfr(ElementType& result, mpfr_srcptr re, const mpfr_srcptr im) const
-  {
-    mpfr_set(&result.re, re, MPFR_RNDN);
-    mpfr_set(&result.im, im, MPFR_RNDN);
-    return true;
-  }
-
   // arithmetic
   void negate(ElementType& result, const ElementType& a) const
   {
@@ -413,7 +401,7 @@ class ARingCCC : public SimpleARing<ARingCCC>
   {
     ElementType curr_pow;
     init(curr_pow);
-    set_from_long(result, 1);
+    set(result, 1);
     if (n == 0)
       {
       }
@@ -534,15 +522,15 @@ class ARingCCC : public SimpleARing<ARingCCC>
   {
     mpfr_set(&c.im, &a, MPFR_RNDN);
   }
-  void set_from_BigReals(ElementType& result, gmp_RR re, gmp_RR im) const
+  void set(ElementType& result, gmp_RR re, gmp_RR im) const
   {
     mpfr_set(&result.re, re, MPFR_RNDN);
     mpfr_set(&result.im, im, MPFR_RNDN);
   }
-  void set_from_doubles(ElementType& result, double re, double im) const
+  void set(ElementType& result, double re, double im) const
   {
-    mRRR.set_from_double(result.re, re);
-    mRRR.set_from_double(result.im, im);
+    mRRR.set(result.re, re);
+    mRRR.set(result.im, im);
   }
 
   void zeroize_tiny(gmp_RR epsilon, ElementType& a) const

--- a/M2/Macaulay2/e/basic-rings/aring-CCi.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-CCi.hpp
@@ -133,12 +133,6 @@ class ARingCCi : public SimpleARing<ARingCCi>
     mpfi_set(&result.im, &a.im);
   }
 
-  void set(ElementType &result, const gmp_CCi a) const
-  {
-    mpfi_set(&result.re, a->re);
-    mpfi_set(&result.im, a->im);
-  }
-
   void set_zero(ElementType &result) const
   {
     mpfi_set_si(&result.re, 0);
@@ -155,11 +149,12 @@ class ARingCCi : public SimpleARing<ARingCCi>
     mpfi_set(&result.im, &a.im);
   }
 
-  void set_from_long(ElementType &result, long a) const
+  void set(ElementType &result, long a) const
   {
     mpfi_set_si(&result.re, a);
     mpfi_set_si(&result.im, 0);
   }
+  void set(ElementType &result, int a) const { set(result, (long)a); }
 
   void set_var(ElementType &result, int v) const
   {
@@ -167,81 +162,74 @@ class ARingCCi : public SimpleARing<ARingCCi>
     mpfi_set_si(&result.im, 0);
   }
 
-  void set_from_mpz(ElementType &result, mpz_srcptr a) const
+  void set(ElementType &result, mpz_srcptr a) const
   {
     mpfi_set_z(&result.re, a);
     mpfi_set_si(&result.im, 0);
   }
 
-  bool set_from_mpq(ElementType &result, mpq_srcptr a) const
+  bool set(ElementType &result, mpq_srcptr a) const
   {
     mpfi_set_q(&result.re, a);
     mpfi_set_si(&result.im, 0);
     return true;
   }
 
-  bool set_from_double(ElementType &result, double a) const
+  bool set(ElementType &result, double a) const
   {
     mpfi_set_d(&result.re, a);
     mpfi_set_si(&result.im, 0);
     return true;
   }
     
-  bool set_from_BigReal(ElementType &result, gmp_RR a) const
+  bool set(ElementType &result, gmp_RR a) const
   {
     mpfi_set_fr(&result.re, a);
     mpfi_set_si(&result.im, 0);
     return true;
   }
     
-  bool set_from_Interval(ElementType &result, gmp_RRi a) const
+  bool set(ElementType &result, gmp_RRi a) const
   {
     mpfi_set(&result.re, a);
     mpfi_set_si(&result.im, 0);
     return true;
   }
 
-  bool set_from_BigComplex(ElementType &result, gmp_CC a) const
+  bool set(ElementType &result, gmp_CC a) const
   {
     mpfi_set_fr(&result.re, a->re);
     mpfi_set_fr(&result.im, a->im);
     return true;
   }
 
-  bool set_from_BigComplex(ElementType &result, const cc_struct * a) const
+  bool set(ElementType &result, const cc_struct * a) const
   {
     mpfi_set_fr(&result.re, &a->re);
     mpfi_set_fr(&result.im, &a->im);
     return true;
   }
 
-  bool set_from_complex_double(ElementType &result, double re, double im) const
-  {
-    mpfi_set_d(&result.re, re);
-    mpfi_set_d(&result.im, im);
-    return true;
-  }
-
-  bool set_from_ComplexInterval(ElementType &result, gmp_CCi a) const
+  bool set(ElementType &result, gmp_CCi a) const
   {
     mpfi_set(&result.re, a->re);
     mpfi_set(&result.im, a->im);
     return true;
   }
 
-  bool set_from_ComplexInterval(ElementType &result, ElementType &a) const
+  bool set(ElementType &result, ElementType &a) const
   {
     mpfi_set(&result.re, &a.re);
     mpfi_set(&result.im, &a.im);
     return true;
   }
 
-  void set_from_BigReals(ElementType& result, gmp_RR re, gmp_RR im) const
+  void set(ElementType& result, gmp_RR re, gmp_RR im) const
     {
       mpfi_set_fr(&result.re, re);
       mpfi_set_fr(&result.im, im);
     }
-  void set_from_doubles(ElementType& result, double re, double im) const
+  void set(ElementType& result, double re, double im) const
     {
       mpfi_set_d(&result.re, re);
       mpfi_set_d(&result.im, im);

--- a/M2/Macaulay2/e/basic-rings/aring-GF-flint-big.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-GF-flint-big.hpp
@@ -194,33 +194,34 @@ class ARingGFFlintBig : public RingInterface
   void set(ElementType& result, const ElementType& a) const { copy(result, a); }
   void set_zero(ElementType& result) const { fq_nmod_zero(&result, mContext); }
   void clear(ElementType& result) const { fq_nmod_clear(&result, mContext); }
-  void set_from_long(ElementType& result, long a) const
+  void set(ElementType& result, long a) const
   {
     long a1 = a % characteristic();
     if (a1 < 0) a1 += characteristic();
     fq_nmod_set_ui(&result, a1, mContext);
   }
+  void set(ElementType& result, int a) const { set(result, (long)a); }
 
   void set_var(ElementType& result, int v) const
   {
-    if (v != 0) set_from_long(result, 1);
+    if (v != 0) set(result, 1);
     std::vector<long> poly = {0, 1};
     fromSmallIntegerCoefficients(result, poly);
   }
 
-  void set_from_mpz(ElementType& result, mpz_srcptr a) const
+  void set(ElementType& result, mpz_srcptr a) const
   {
     int b = static_cast<int>(mpz_fdiv_ui(a, characteristic()));
-    set_from_long(result, b);
+    set(result, b);
   }
 
-  bool set_from_mpq(ElementType& result, mpq_srcptr a) const
+  bool set(ElementType& result, mpq_srcptr a) const
   {
     ElementType n, d;
     init(n);
     init(d);
-    set_from_mpz(n, mpq_numref(a));
-    set_from_mpz(d, mpq_denref(a));
+    set(n, mpq_numref(a));
+    set(d, mpq_denref(a));
     if (is_zero(d)) return false;
     divide(result, n, d);
     return true;
@@ -355,7 +356,7 @@ class ARingGFFlintBig : public RingInterface
   {
     assert(not is_zero(a));
     assert(not is_zero(b));
-    set_from_long(x, 1);
+    set(x, 1);
     divide(y, a, b);
     negate(y, y);
   }

--- a/M2/Macaulay2/e/basic-rings/aring-GF-flint.cpp
+++ b/M2/Macaulay2/e/basic-rings/aring-GF-flint.cpp
@@ -130,7 +130,7 @@ void ARingGFFlint::getGenerator(ElementType& result_gen) const
       fq_zech_init(&mCachedGenerator, mContext);
       if (mCharacteristic == 2 and mDimension == 1)
         // This is currently a bug in flint...
-        set_from_long(mCachedGenerator, 1);
+        set(mCachedGenerator, 1);
       else
         fq_zech_gen(&mCachedGenerator, mContext);
 

--- a/M2/Macaulay2/e/basic-rings/aring-GF-flint.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-GF-flint.hpp
@@ -174,34 +174,35 @@ class ARingGFFlint : public RingInterface
   void set(ElementType& result, const ElementType& a) const { copy(result, a); }
   void set_zero(ElementType& result) const { fq_zech_zero(&result, mContext); }
   void clear(ElementType& result) const { fq_zech_clear(&result, mContext); }
-  void set_from_long(ElementType& result, long a) const
+  void set(ElementType& result, long a) const
   {
     long a1 = a % characteristic();
     if (a1 < 0) a1 += characteristic();
     fq_zech_set_ui(&result, a1, mContext);
   }
+  void set(ElementType& result, int a) const { set(result, (long)a); }
 
   void set_var(ElementType& result, int v) const
   {
-    if (v != 0) set_from_long(result, 1);
+    if (v != 0) set(result, 1);
     std::vector<long> poly = {0, 1};
     fromSmallIntegerCoefficients(result, poly);
     // printf("variable is %lu\n", result.value);
   }
 
-  void set_from_mpz(ElementType& result, mpz_srcptr a) const
+  void set(ElementType& result, mpz_srcptr a) const
   {
     int b = static_cast<int>(mpz_fdiv_ui(a, characteristic()));
-    set_from_long(result, b);
+    set(result, b);
   }
 
-  bool set_from_mpq(ElementType& result, mpq_srcptr a) const
+  bool set(ElementType& result, mpq_srcptr a) const
   {
     ElementType n, d;
     init(n);
     init(d);
-    set_from_mpz(n, mpq_numref(a));
-    set_from_mpz(d, mpq_denref(a));
+    set(n, mpq_numref(a));
+    set(d, mpq_denref(a));
     if (is_zero(d)) return false;
     divide(result, n, d);
     return true;
@@ -331,7 +332,7 @@ class ARingGFFlint : public RingInterface
   {
     assert(not is_zero(a));
     assert(not is_zero(b));
-    set_from_long(x, 1);
+    set(x, 1);
     divide(y, a, b);
     negate(y, y);
   }

--- a/M2/Macaulay2/e/basic-rings/aring-QQ-flint.cpp
+++ b/M2/Macaulay2/e/basic-rings/aring-QQ-flint.cpp
@@ -76,7 +76,7 @@ void ARingQQFlint::syzygy(const ElementType& a,
                           ElementType& y) const
 {
   assert(!is_zero(b));
-  set_from_long(x, 1);
+  set(x, 1);
   divide(y, a, b);
   negate(y, y);
 }

--- a/M2/Macaulay2/e/basic-rings/aring-QQ-flint.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-QQ-flint.hpp
@@ -98,19 +98,20 @@ class ARingQQFlint : public SimpleARing<ARingQQFlint>
   }
 
   void set_zero(ElementType& result) const { fmpq_zero(&result); }
-  void set_from_long(ElementType& result, long a) const
+  void set(ElementType& result, long a) const
   {
     fmpq_set_si(&result, a, 1);
   }
+  void set(ElementType& result, int a) const { fmpq_set_si(&result, a, 1); }
 
-  void set_from_mpz(ElementType& result, mpz_srcptr a) const
+  void set(ElementType& result, mpz_srcptr a) const
   {
-    // printf("ARingQQFlint::calling set_from_mpz\n");
+    // printf("ARingQQFlint::calling set\n");
     fmpz_set_mpz(fmpq_numref(&result), a);
     fmpz_one(fmpq_denref(&result));
   }
 
-  bool set_from_mpq(ElementType& result, mpq_srcptr a) const
+  bool set(ElementType& result, mpq_srcptr a) const
   {
     fmpq_set_mpq(&result, a);
     return true;
@@ -260,7 +261,7 @@ class ARingQQFlint : public SimpleARing<ARingQQFlint>
     // Rf = ZZ ---> QQ
     if (Rf->is_ZZ())
       {
-        set_from_mpz(result, f.get_mpz());
+        set(result, f.get_mpz());
         return true;
       }
     return false;

--- a/M2/Macaulay2/e/basic-rings/aring-QQ-gmp.cpp
+++ b/M2/Macaulay2/e/basic-rings/aring-QQ-gmp.cpp
@@ -67,7 +67,7 @@ void ARingQQGMP::syzygy(const ElementType& a,
                         ElementType& y) const
 {
   assert(!is_zero(b));
-  set_from_long(x, 1);
+  set(x, 1);
   divide(y, a, b);
   negate(y, y);
 }

--- a/M2/Macaulay2/e/basic-rings/aring-QQ-gmp.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-QQ-gmp.hpp
@@ -93,12 +93,13 @@ class ARingQQGMP : public SimpleARing<ARingQQGMP>
   }
 
   void set_zero(ElementType& result) const { mpq_set_si(&result, 0, 1); }
-  void set_from_long(ElementType& result, long a) const
+  void set(ElementType& result, long a) const
   {
     mpq_set_si(&result, a, 1);
   }
+  void set(ElementType& result, int a) const { set(result, (long)a); }
 
-  void set_from_mpz(ElementType& result, mpz_srcptr a) const
+  void set(ElementType& result, mpz_srcptr a) const
   {
     mpz_set(mpq_numref(&result), a);
     mpz_set_ui(mpq_denref(&result), 1);
@@ -114,7 +115,7 @@ class ARingQQGMP : public SimpleARing<ARingQQGMP>
     return false;
   }
 
-  bool set_from_mpq(ElementType& result, mpq_srcptr a) const
+  bool set(ElementType& result, mpq_srcptr a) const
   {
     mpq_set(&result, a);
     return true;
@@ -134,7 +135,7 @@ class ARingQQGMP : public SimpleARing<ARingQQGMP>
   // negative, which means both n0 and d0 can come out with the same
   // negative sign.  We negate both before storing into the mpq_t,
   // which requires a positive denominator.
-  bool set_from_double(ElementType& result, double a) const
+  bool set(ElementType& result, double a) const
   {
     bool negative, success;
     double q, r;
@@ -206,7 +207,7 @@ class ARingQQGMP : public SimpleARing<ARingQQGMP>
     return success;
   }
 
-  bool set_from_BigReal(ElementType& result, gmp_RR a) const
+  bool set(ElementType& result, gmp_RR a) const
   {
     bool negative, success;
     mpfr_prec_t prec;
@@ -445,7 +446,7 @@ class ARingQQGMP : public SimpleARing<ARingQQGMP>
       // Rf = ZZ ---> QQ
       if (Rf->is_ZZ())
         {
-          set_from_mpz(result, f.get_mpz());
+          set(result, f.get_mpz());
           return true;
         }
       return false;

--- a/M2/Macaulay2/e/basic-rings/aring-RR.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-RR.hpp
@@ -81,7 +81,6 @@ class ARingRR : public SimpleARing<ARingRR>
 
   void init(ElementType &result) const { result = 0.0; }
   void init_set(ElementType &result, const ElementType &a) const { result = a; }
-  void set(ElementType &result, const ElementType &a) const { result = a; }
   void set_zero(ElementType &result) const { result = 0.0; }
   static void clear(ElementType &result)
   {
@@ -89,10 +88,11 @@ class ARingRR : public SimpleARing<ARingRR>
   }
 
   void copy(ElementType &result, const ElementType &a) const { set(result, a); }
-  void set_from_long(ElementType &result, long a) const
+  void set(ElementType &result, long a) const
   {
     result = static_cast<double>(a);
   }
+  void set(ElementType &result, int a) const { result = a; }
 
   void set_var(ElementType &result, int v) const
   {
@@ -100,23 +100,23 @@ class ARingRR : public SimpleARing<ARingRR>
     result = 1.0;
   }
 
-  void set_from_mpz(ElementType &result, mpz_srcptr a) const
+  void set(ElementType &result, mpz_srcptr a) const
   {
     result = mpz_get_d(a);
   }
 
-  bool set_from_mpq(ElementType &result, mpq_srcptr a) const
+  bool set(ElementType &result, mpq_srcptr a) const
   {
     result = mpq_get_d(a);
     return true;
   }
 
-  bool set_from_BigReal(ElementType &result, gmp_RR a) const
+  bool set(ElementType &result, gmp_RR a) const
   {
     result = mpfr_get_d(a, MPFR_RNDN);
     return true;
   }
-  bool set_from_double(ElementType &result, double a) const
+  bool set(ElementType &result, double a) const
   {
     result = a;
     return true;

--- a/M2/Macaulay2/e/basic-rings/aring-RRR.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-RRR.hpp
@@ -109,10 +109,11 @@ class ARingRRR : public SimpleARing<ARingRRR>
     mpfr_set(&result, &a, MPFR_RNDN);
   }
 
-  void set_from_long(ElementType &result, long a) const
+  void set(ElementType &result, long a) const
   {
     mpfr_set_si(&result, a, MPFR_RNDN);
   }
+  void set(ElementType &result, int a) const { set(result, (long)a); }
 
   void set_var(ElementType &result, int v) const
   {
@@ -120,23 +121,23 @@ class ARingRRR : public SimpleARing<ARingRRR>
     mpfr_set_si(&result, 1, MPFR_RNDN);
   }
 
-  void set_from_mpz(ElementType &result, mpz_srcptr a) const
+  void set(ElementType &result, mpz_srcptr a) const
   {
     mpfr_set_z(&result, a, MPFR_RNDN);
   }
 
-  bool set_from_mpq(ElementType &result, mpq_srcptr a) const
+  bool set(ElementType &result, mpq_srcptr a) const
   {
     mpfr_set_q(&result, a, MPFR_RNDN);
     return true;
   }
 
-  bool set_from_double(ElementType &result, double a) const
+  bool set(ElementType &result, double a) const
   {
     mpfr_set_d(&result, a, MPFR_RNDN);
     return true;
   }
-  bool set_from_BigReal(ElementType &result, gmp_RR a) const
+  bool set(ElementType &result, gmp_RR a) const
   {
     mpfr_set(&result, a, MPFR_RNDN);
     return true;

--- a/M2/Macaulay2/e/basic-rings/aring-RRi.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-RRi.hpp
@@ -121,40 +121,41 @@ class ARingRRi : public SimpleARing<ARingRRi>
     mpfi_set(&result, &a);
   }
 
-  void set_from_long(ElementType &result, long a) const
+  void set(ElementType &result, long a) const
   {
     mpfi_set_si(&result, a);
   }
+  void set(ElementType &result, int a) const { set(result, (long)a); }
 
   void set_var(ElementType &result, int v) const
   {
     mpfi_set_si(&result, v);
   }
 
-  void set_from_mpz(ElementType &result, mpz_srcptr a) const
+  void set(ElementType &result, mpz_srcptr a) const
   {
     mpfi_set_z(&result, a);
   }
 
-  bool set_from_mpq(ElementType &result, mpq_srcptr a) const
+  bool set(ElementType &result, mpq_srcptr a) const
   {
     mpfi_set_q(&result, a);
     return true;
   }
 
-  bool set_from_double(ElementType &result, double a) const
+  bool set(ElementType &result, double a) const
   {
     mpfi_set_d(&result, a);
     return true;
   }
     
-  bool set_from_BigReal(ElementType &result, gmp_RR a) const
+  bool set(ElementType &result, gmp_RR a) const
   {
     mpfi_set_fr(&result, a);
     return true;
   }
     
-  bool set_from_Interval(ElementType &result, gmp_RRi a) const
+  bool set(ElementType &result, gmp_RRi a) const
   {
     mpfi_set(&result, a);
     return true;

--- a/M2/Macaulay2/e/basic-rings/aring-ZZ-flint.cpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZ-flint.cpp
@@ -66,19 +66,19 @@ void ARingZZ::syzygy(const ElementType& a,
   // First check the special cases a = 0, b = 1, -1.  Other cases: use gcd.
   if (is_zero(a))
     {
-      set_from_long(x, 1);
+      set(x, 1);
       set_zero(y);
       return;
     }
   if (fmpz_cmp_ui(&b, 1) == 0)
     {
-      set_from_long(x, 1);
+      set(x, 1);
       negate(y, a);
       return;
     }
   if (fmpz_cmp_si(&b, -1) == 0)
     {
-      set_from_long(x, 1);
+      set(x, 1);
       set(y, a);
       return;
     }

--- a/M2/Macaulay2/e/basic-rings/aring-ZZ-flint.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZ-flint.hpp
@@ -90,22 +90,19 @@ class ARingZZ : public SimpleARing<ARingZZ>
   }
 
   void set_zero(ElementType& result) const { fmpz_set_si(&result, 0); }
-  void set_from_long(ElementType& result, long a) const
-  {
-    fmpz_set_si(&result, a);
-  }
+  void set(ElementType& result, int a) const { fmpz_set_si(&result, a); }
 
-void set_from_mpz(ElementType& result, mpz_srcptr a) const
+void set(ElementType& result, mpz_srcptr a) const
   {
-    // printf("ARingZZ::calling set_from_mpz\n");
+    // printf("ARingZZ::calling set\n");
     fmpz_set_mpz(&result, a);
   }
 
-  bool set_from_mpq(ElementType& result, mpq_srcptr a) const
+  bool set(ElementType& result, mpq_srcptr a) const
   {
     if (mpz_cmp_si(mpq_denref(a), 1) == 0)
       {
-        set_from_mpz(result, mpq_numref(a));
+        set(result, mpq_numref(a));
         return true;
       }
     return false;

--- a/M2/Macaulay2/e/basic-rings/aring-ZZ-gmp.cpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZ-gmp.cpp
@@ -53,19 +53,19 @@ void ARingZZGMP::syzygy(const ElementType& a,
   // First check the special cases a = 0, b = 1, -1.  Other cases: use gcd.
   if (is_zero(a))
     {
-      set_from_long(x, 1);
+      set(x, 1);
       set_zero(y);
       return;
     }
   if (mpz_cmp_ui(&b, 1) == 0)
     {
-      set_from_long(x, 1);
+      set(x, 1);
       negate(y, a);
       return;
     }
   if (mpz_cmp_si(&b, -1) == 0)
     {
-      set_from_long(x, 1);
+      set(x, 1);
       set(y, a);
       return;
     }

--- a/M2/Macaulay2/e/basic-rings/aring-ZZ-gmp.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZ-gmp.hpp
@@ -83,28 +83,29 @@ class ARingZZGMP : public SimpleARing<ARingZZGMP>
   }
 
   void set_zero(ElementType& result) const { mpz_set_si(&result, 0); }
-  void set_from_long(ElementType& result, long a) const
+  void set(ElementType& result, long a) const
   {
     mpz_set_si(&result, a);
   }
+  void set(ElementType& result, int a) const { mpz_set_si(&result, a); }
 
-  void set_from_mpz(ElementType& result, mpz_srcptr a) const
+  void set(ElementType& result, mpz_srcptr a) const
   {
-    // printf("ARingZZ::calling set_from_mpz\n");
+    // printf("ARingZZ::calling set\n");
     mpz_set(&result, a);
   }
 
-  bool set_from_mpq(ElementType& result, mpq_srcptr a) const
+  bool set(ElementType& result, mpq_srcptr a) const
   {
     if (mpz_cmp_si(mpq_denref(a), 1) == 0)
       {
-        set_from_mpz(result, mpq_numref(a));
+        set(result, mpq_numref(a));
         return true;
       }
     return false;
   }
 
-  bool set_from_BigReal(ElementType& result, gmp_RR a) const
+  bool set(ElementType& result, gmp_RR a) const
   {
     (void) result;
     (void) a;

--- a/M2/Macaulay2/e/basic-rings/aring-ZZp-ffpack.cpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZp-ffpack.cpp
@@ -38,7 +38,7 @@ ARingZZpFFPACK::ElementType ARingZZpFFPACK::computeGenerator() const
   for (UTT currIntElem = 2; currIntElem < mCharac; currIntElem++)
     {
       ElementType currElem;
-      set_from_long(currElem, currIntElem);
+      set(currElem, (long)currIntElem);
       bool found = true;
       ElementType tmpElem = currElem;
       for (UTT count = 0; count < mCharac - 2; count++)
@@ -101,22 +101,22 @@ void ARingZZpFFPACK::copy(ElementType &result, const ElementType a) const
 }
 
 /// @todo possible problem if type UTT is smaller than an int?
-void ARingZZpFFPACK::set_from_long(ElementType &result, long a) const
+void ARingZZpFFPACK::set(ElementType &result, long a) const
 {
   mFfpackField.init(result, a);
 }
 
-void ARingZZpFFPACK::set_from_mpz(ElementType &result, mpz_srcptr a) const
+void ARingZZpFFPACK::set(ElementType &result, mpz_srcptr a) const
 {
   unsigned long b = static_cast<UTT>(mpz_fdiv_ui(a, mCharac));
   mFfpackField.init(result, b);
 }
 
-bool ARingZZpFFPACK::set_from_mpq(ElementType &result, mpq_srcptr a) const
+bool ARingZZpFFPACK::set(ElementType &result, mpq_srcptr a) const
 {
   ElementType n, d;
-  set_from_mpz(n, mpq_numref(a));
-  set_from_mpz(d, mpq_denref(a));
+  set(n, mpq_numref(a));
+  set(d, mpq_denref(a));
   if (is_zero(d)) return false;
   divide(result, n, d);
   return true;
@@ -192,7 +192,7 @@ void ARingZZpFFPACK::power(ElementType &result,
       if (n < 0)
         throw exc::division_by_zero_error();
       else if (n == 0)
-        set_from_long(result, 1);
+        set(result, 1);
       else
         set_zero(result);
       return;
@@ -205,7 +205,7 @@ void ARingZZpFFPACK::power(ElementType &result,
       n = -n;
     }
   n = n % (mCharac - 1);
-  set_from_long(result, 1);
+  set(result, 1);
   if (n == 0) return;
 
   // Now use doubling algorithm
@@ -231,7 +231,7 @@ void ARingZZpFFPACK::power_mpz(ElementType &result,
       if (mpz_sgn(n) < 0)
         throw exc::division_by_zero_error();
       else if (mpz_sgn(n) == 0)
-        set_from_long(result, 1);
+        set(result, 1);
       else
         set_zero(result);
     }

--- a/M2/Macaulay2/e/basic-rings/aring-ZZp-ffpack.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZp-ffpack.hpp
@@ -154,11 +154,12 @@ class ARingZZpFFPACK : public SimpleARing<ARingZZpFFPACK>
 
   void copy(ElementType &result, const ElementType a) const;
 
-  void set_from_long(ElementType &result, long a) const;
+  void set(ElementType &result, long a) const;
+  void set(ElementType &result, int a) const { set(result, (long)a); }
 
-  void set_from_mpz(ElementType &result, mpz_srcptr a) const;
+  void set(ElementType &result, mpz_srcptr a) const;
 
-  bool set_from_mpq(ElementType &result, mpq_srcptr a) const;
+  bool set(ElementType &result, mpq_srcptr a) const;
 
   ElementType computeGenerator() const;
 

--- a/M2/Macaulay2/e/basic-rings/aring-ZZp-flint.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZp-flint.hpp
@@ -87,16 +87,17 @@ class ARingZZpFlint : public SimpleARing<ARingZZpFlint>
 
   void set(ElementType &result, ElementType a) const { result = a; }
   void set_zero(ElementType &result) const { result = 0; }
-  void set_from_long(ElementType &result, long a) const
+  void set(ElementType &result, long a) const
   {
     // printf("called deprecated and inefficient
-    // ARingZZpFlint::set_from_long\n");
+    // ARingZZpFlint::set\n");
     fmpz_t b;
     fmpz_init(b);
     fmpz_set_si(b, a);
     result = fmpz_fdiv_ui(b, mCharac);
     fmpz_clear(b);
   }
+  void set(ElementType &result, int a) const { set(result, (long)a); }
 
   void set_var(ElementType &result, int v) const
   {
@@ -104,16 +105,16 @@ class ARingZZpFlint : public SimpleARing<ARingZZpFlint>
     result = 1;
   }
 
-  void set_from_mpz(ElementType &result, mpz_srcptr a) const
+  void set(ElementType &result, mpz_srcptr a) const
   {
     result = mpz_fdiv_ui(a, mCharac);
   }
 
-  bool set_from_mpq(ElementType &result, mpq_srcptr a) const
+  bool set(ElementType &result, mpq_srcptr a) const
   {
     ElementType n, d;
-    set_from_mpz(n, mpq_numref(a));
-    set_from_mpz(d, mpq_denref(a));
+    set(n, mpq_numref(a));
+    set(d, mpq_denref(a));
     if (is_zero(d)) return false;
     divide(result, n, d);
     return true;
@@ -186,7 +187,7 @@ class ARingZZpFlint : public SimpleARing<ARingZZpFlint>
       {
         // case a == 0
         if (n < 0) throw exc::division_by_zero_error();
-        if (n == 0) return set_from_long(result, 1);
+        if (n == 0) return set(result, 1);
         if (n > 0) return set_zero(result);
       }
   }
@@ -202,7 +203,7 @@ class ARingZZpFlint : public SimpleARing<ARingZZpFlint>
       {
         // case a == 0
         if (mpz_sgn(n) == 0)
-          set_from_long(result, 1);
+          set(result, 1);
         else if (mpz_sgn(n) > 0)
           set_zero(result);
         else

--- a/M2/Macaulay2/e/basic-rings/aring-ZZp.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZp.hpp
@@ -112,7 +112,7 @@ class ARingZZp : public SimpleARing<ARingZZp>
   static void clear(elem &result) { (void) result; }
 
   void set_zero(elem &result) const { result = 0; }
-  void set_from_long(elem &result, long a) const
+  void set(elem &result, long a) const
   {
     a = a % p;
     if (a < 0) a += p;
@@ -125,17 +125,17 @@ class ARingZZp : public SimpleARing<ARingZZp>
     result = 1;
   }
 
-  void set_from_mpz(elem &result, mpz_srcptr a) const
+  void set(elem &result, mpz_srcptr a) const
   {
     int b = static_cast<int>(mpz_fdiv_ui(a, p));
     result = log_table[b];
   }
 
-  bool set_from_mpq(elem &result, mpq_srcptr a) const
+  bool set(elem &result, mpq_srcptr a) const
   {
     ElementType n, d;
-    set_from_mpz(n, mpq_numref(a));
-    set_from_mpz(d, mpq_denref(a));
+    set(n, mpq_numref(a));
+    set(d, mpq_denref(a));
     if (is_zero(d)) return false;
     divide(result, n, d);
     return true;

--- a/M2/Macaulay2/e/basic-rings/aring-ZZp.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-ZZp.hpp
@@ -52,7 +52,7 @@ class ARingZZp : public SimpleARing<ARingZZp>
   /////////////////////////////////////////////////////////
   unsigned int computeHashValue(const elem &a) const { return a; }
   void init_set(elem &result, elem a) const { result = a; }
-  void set(elem &result, elem a) const { result = a; }
+  void copy(elem &result, elem a) const { result = a; }
   /////////////////////////////////
   // ElementType informational ////
   /////////////////////////////////
@@ -112,6 +112,7 @@ class ARingZZp : public SimpleARing<ARingZZp>
   static void clear(elem &result) { (void) result; }
 
   void set_zero(elem &result) const { result = 0; }
+  void set(elem &result, int a) const { set(result, (long)a); }
   void set(elem &result, long a) const
   {
     a = a % p;

--- a/M2/Macaulay2/e/basic-rings/aring-glue.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-glue.hpp
@@ -109,7 +109,7 @@ class ConcreteRing : public Ring
     if (displayArithmeticCalls) fprintf(stderr, "calling from_long\n");
     ring_elem result;
     Element a(*R);
-    R->set_from_long(a, n);
+    R->set(a, n);
     R->to_ring_elem(result, a);
     return result;
   }
@@ -119,14 +119,14 @@ class ConcreteRing : public Ring
     if (displayArithmeticCalls) fprintf(stderr, "calling from_int(mpz)\n");
     ring_elem result;
     Element a(*R);
-    R->set_from_mpz(a, n);
+    R->set(a, n);
     R->to_ring_elem(result, a);
     return result;
   }
   virtual bool from_rational(mpq_srcptr q, ring_elem &result) const
   {
     Element a(*R);
-    bool ret = R->set_from_mpq(a, q);
+    bool ret = R->set(a, q);
     if (ret) R->to_ring_elem(result, a);
     return ret;
   }
@@ -157,7 +157,7 @@ class ConcreteRing : public Ring
   virtual bool from_BigComplex(gmp_CC q, ring_elem &result) const
   {
     Element a(*R);
-    //      bool ret = R->set_from_BigComplex(a,q);
+    //      bool ret = R->set(a,q);
     bool ret = get_from_BigComplex(*R, a, q);
     if (ret) R->to_ring_elem(result, a);
     return ret;

--- a/M2/Macaulay2/e/basic-rings/aring-glue.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-glue.hpp
@@ -133,7 +133,7 @@ class ConcreteRing : public Ring
   virtual bool from_BigReal(gmp_RR q, ring_elem &result) const
   {
     Element a(*R);
-    bool ret = get_from_BigReal(*R, a, q);
+    bool ret = try_set(*R, a, q);
     if (ret) R->to_ring_elem(result, a);
     return ret;
   }
@@ -141,7 +141,7 @@ class ConcreteRing : public Ring
   virtual bool from_Interval(gmp_RRi q, ring_elem &result) const
   {
     Element a(*R);
-    bool ret = get_from_Interval(*R, a, q);
+    bool ret = try_set(*R, a, q);
     if (ret) R->to_ring_elem(result, a);
     return ret;
   }
@@ -149,7 +149,7 @@ class ConcreteRing : public Ring
   virtual bool from_ComplexInterval(gmp_CCi z, ring_elem &result) const
     {
         Element a(*R);
-        bool ret = get_from_ComplexInterval(*R, a , z);
+        bool ret = try_set(*R, a , z);
         if (ret) R->to_ring_elem(result, a);
         return ret;
     }
@@ -158,14 +158,14 @@ class ConcreteRing : public Ring
   {
     Element a(*R);
     //      bool ret = R->set(a,q);
-    bool ret = get_from_BigComplex(*R, a, q);
+    bool ret = try_set(*R, a, q);
     if (ret) R->to_ring_elem(result, a);
     return ret;
   }
   virtual bool from_double(double q, ring_elem &result) const
   {
     Element a(*R);
-    bool ret = get_from_double(*R, a, q);
+    bool ret = try_set(*R, a, q);
     if (ret) R->to_ring_elem(result, a);
     return ret;
   }
@@ -174,7 +174,7 @@ class ConcreteRing : public Ring
                                    ring_elem &result) const
   {
     Element a(*R);
-    bool ret = get_from_complex_double(*R, a, re, im);
+    bool ret = try_set(*R, a, re, im);
     if (ret) R->to_ring_elem(result, a);
     return ret;
   }

--- a/M2/Macaulay2/e/basic-rings/aring-glue.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-glue.hpp
@@ -263,7 +263,7 @@ class ConcreteRing : public Ring
     const ElementType &a = R->from_ring_elem_const(f);
     Element b(*R);
     ring_elem result;
-    R->set(b, a);
+    R->copy(b.value(), a);
     R->to_ring_elem(result, b);
     return result;
   }

--- a/M2/Macaulay2/e/basic-rings/aring-m2-GF.cpp
+++ b/M2/Macaulay2/e/basic-rings/aring-m2-GF.cpp
@@ -131,7 +131,7 @@ void ARingGFM2::fromSmallIntegerCoefficients(
   for (long i = 0; i < poly.size(); i++)
     if (poly[i] != 0)
       {
-        set_from_long(a, poly[i]);
+        set(a, poly[i]);
         power(b, mGF.generatorExponent(), i);
         mult(a, a, b);
         add(result, result, a);

--- a/M2/Macaulay2/e/basic-rings/aring-m2-GF.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-m2-GF.hpp
@@ -157,7 +157,7 @@ class ARingGFM2 : public SimpleARing<ARingGFM2>
   void set_zero(elem &result) const { result = 0; }
   static void clear(elem &result) { (void) result; }
 
-  void set_from_long(elem &result, long a) const
+  void set(elem &result, long a) const
   {
     int a1 = static_cast<int>(a % characteristic());
     if (a1 < 0) a1 += characteristic();
@@ -170,17 +170,17 @@ class ARingGFM2 : public SimpleARing<ARingGFM2>
     result = 1;
   }
 
-  void set_from_mpz(elem &result, mpz_srcptr a) const
+  void set(elem &result, mpz_srcptr a) const
   {
     int b = static_cast<int>(mpz_fdiv_ui(a, characteristic()));
     result = mGF.fromZZTable(b);
   }
 
-  bool set_from_mpq(elem &result, mpq_srcptr a) const
+  bool set(elem &result, mpq_srcptr a) const
   {
     elem n, d;
-    set_from_mpz(n, mpq_numref(a));
-    set_from_mpz(d, mpq_denref(a));
+    set(n, mpq_numref(a));
+    set(d, mpq_denref(a));
     if (is_zero(d)) return false;
     divide(result, n, d);
     return true;

--- a/M2/Macaulay2/e/basic-rings/aring-m2-GF.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-m2-GF.hpp
@@ -153,7 +153,7 @@ class ARingGFM2 : public SimpleARing<ARingGFM2>
   void copy(elem &result, elem a) const { result = a; }
   void init(elem &result) const { result = 0; }
   void init_set(elem &result, elem a) const { result = a; }
-  void set(elem &result, elem a) const { result = a; }
+  void set(elem &result, int a) const { set(result, (long)a); }
   void set_zero(elem &result) const { result = 0; }
   static void clear(elem &result) { (void) result; }
 

--- a/M2/Macaulay2/e/basic-rings/aring-tower.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-tower.hpp
@@ -204,22 +204,23 @@ class ARingTower : public RingInterface
   void clear(elem &f) const { clear(mStartLevel, f); }
   void set_zero(elem &result) const { result = nullptr; }
   void copy(elem &result, elem a) const { result = copy(mStartLevel, a); }
-  void set_from_long(elem &result, long a) const
+  void set(elem &result, long a) const
   {  // TODO: write this
     (void) result;
     (void) a;
   }
+  void set(elem &result, int a) const { set(result, (long)a); }
 
   // v from 0..n_vars()-1, sets result to 0 if v is out of range
   void set_var(elem &result, int v) const { result = var(mStartLevel, v); }
-  void set_from_mpz(elem &result, mpz_srcptr a) const
+  void set(elem &result, mpz_srcptr a) const
   {
     (void) result;
     (void) a;
     assert(false);
   }  // TODO: write this
 
-  bool set_from_mpq(elem &result, mpq_srcptr a) const
+  bool set(elem &result, mpq_srcptr a) const
   {
     (void) result;
     (void) a;
@@ -420,15 +421,15 @@ class ARingTower : public RingInterface
     void set_zero(ElementType &result) const { result = 0; }
     
     
-    void set_from_long(ElementType &result, long r) {
+    void set(ElementType &result, long r) {
       r = r % mCharacteristic;
       if (r < 0) r += P;
       result = mRing.from_long(mStartLevel, r);
     }
     
-    void set_from_int(ElementType &result, mpz_ptr r);
+    void set(ElementType &result, mpz_ptr r);
     
-    bool set_from_mpq(ElementType &result, mpq_srcptr r);
+    bool set(ElementType &result, mpq_srcptr r);
     
     void set_random(ElementType &result) { result = mRing.random(mStartLevel); }
     

--- a/M2/Macaulay2/e/basic-rings/aring-translate.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-translate.hpp
@@ -35,72 +35,66 @@ namespace detail {
 
 template <typename RT, typename = void>
 inline constexpr bool has_set_from_mpq = false;
-
 template <typename RT>
 inline constexpr bool has_set_from_mpq<
     RT,
-    std::void_t<decltype(std::declval<const RT&>().set_from_mpq(
+    std::void_t<decltype(std::declval<const RT&>().set(
         std::declval<typename RT::ElementType&>(),
         std::declval<mpq_srcptr>()))>> = true;
 
 template <typename RT, typename = void>
 inline constexpr bool has_set_from_double = false;
-
 template <typename RT>
 inline constexpr bool has_set_from_double<
     RT,
-    std::void_t<decltype(std::declval<const RT&>().set_from_double(
-        std::declval<typename RT::ElementType&>(), std::declval<double>()))>> =
-    true;
+    std::enable_if_t<std::is_same_v<
+        decltype(std::declval<const RT&>().set(
+            std::declval<typename RT::ElementType&>(), std::declval<double>())),
+        bool>>> = true;
 
 template <typename RT, typename = void>
 inline constexpr bool has_set_from_BigReal = false;
-
 template <typename RT>
 inline constexpr bool has_set_from_BigReal<
     RT,
-    std::void_t<decltype(std::declval<const RT&>().set_from_BigReal(
+    std::void_t<decltype(std::declval<const RT&>().set(
         std::declval<typename RT::ElementType&>(), std::declval<gmp_RR>()))>> =
     true;
 
 template <typename RT, typename = void>
 inline constexpr bool has_set_from_Interval = false;
-
 template <typename RT>
 inline constexpr bool has_set_from_Interval<
     RT,
-    std::void_t<decltype(std::declval<const RT&>().set_from_Interval(
+    std::void_t<decltype(std::declval<const RT&>().set(
         std::declval<typename RT::ElementType&>(), std::declval<gmp_RRi>()))>> =
     true;
 
 template <typename RT, typename = void>
-inline constexpr bool has_set_from_complex_double = false;
-
+inline constexpr bool has_set_from_doubles = false;
 template <typename RT>
-inline constexpr bool has_set_from_complex_double<
+inline constexpr bool has_set_from_doubles<
     RT,
-    std::void_t<decltype(std::declval<const RT&>().set_from_complex_double(
+    std::void_t<decltype(std::declval<const RT&>().set(
         std::declval<typename RT::ElementType&>(),
         std::declval<double>(),
         std::declval<double>()))>> = true;
 
 template <typename RT, typename = void>
 inline constexpr bool has_set_from_BigComplex = false;
-
 template <typename RT>
 inline constexpr bool has_set_from_BigComplex<
     RT,
-    std::void_t<decltype(std::declval<const RT&>().set_from_BigComplex(
+    std::void_t<decltype(std::declval<const RT&>().set(
         std::declval<typename RT::ElementType&>(), std::declval<gmp_CC>()))>> =
     true;
 
 template <typename RT, typename = void>
 inline constexpr bool has_set_from_ComplexInterval = false;
-
 template <typename RT>
 inline constexpr bool has_set_from_ComplexInterval<
     RT,
-    std::void_t<decltype(std::declval<const RT&>().set_from_ComplexInterval(
+    std::void_t<decltype(std::declval<const RT&>().set(
         std::declval<typename RT::ElementType&>(), std::declval<gmp_CCi>()))>> =
     true;
 }  // namespace detail
@@ -109,7 +103,7 @@ template <typename RT>
 bool get_from_double(const RT& R, typename RT::ElementType& a, double b)
 {
   if constexpr (detail::has_set_from_double<RT>)
-    return R.set_from_double(a, b);
+    return R.set(a, b);
   else
     return false;
 }
@@ -118,7 +112,7 @@ template <typename RT>
 bool get_from_BigReal(const RT& R, typename RT::ElementType& a, gmp_RR b)
 {
   if constexpr (detail::has_set_from_BigReal<RT>)
-    return R.set_from_BigReal(a, b);
+    return R.set(a, b);
   else
     return false;
 }
@@ -127,7 +121,7 @@ template <typename RT>
 bool get_from_Interval(const RT& R, typename RT::ElementType& a, gmp_RRi b)
 {
   if constexpr (detail::has_set_from_Interval<RT>)
-    return R.set_from_Interval(a, b);
+    return R.set(a, b);
   else
     return false;
 }
@@ -138,8 +132,8 @@ bool get_from_complex_double(const RT& R,
                              double re,
                              double im)
 {
-  if constexpr (detail::has_set_from_complex_double<RT>)
-    return R.set_from_complex_double(a, re, im);
+  if constexpr (detail::has_set_from_doubles<RT>)
+    { R.set(a, re, im); return true; }
   else
     return false;
 }
@@ -148,7 +142,7 @@ template <typename RT>
 bool get_from_BigComplex(const RT& R, typename RT::ElementType& a, gmp_CC b)
 {
   if constexpr (detail::has_set_from_BigComplex<RT>)
-    return R.set_from_BigComplex(a, b);
+    return R.set(a, b);
   else
     return false;
 }
@@ -157,7 +151,7 @@ template <typename RT>
 bool get_from_ComplexInterval(const RT& R, typename RT::ElementType & a, gmp_CCi b)
 {
   if constexpr (detail::has_set_from_ComplexInterval<RT>)
-    return R.set_from_ComplexInterval(a, b);
+    return R.set(a, b);
   else
     return false;
 }
@@ -200,7 +194,7 @@ bool mypromote(const ARingQQ& R,
 {
   (void) R;
   if constexpr (detail::has_set_from_mpq<RingS>)
-    return S.set_from_mpq(fS, &fR);
+    return S.set(fS, &fR);
   else
     return false;
 }
@@ -222,7 +216,7 @@ inline bool mypromote(const ARingRR& R,
                       ARingRRR::ElementType& fS)
 {
   (void) R;
-  S.set_from_double(fS, fR);
+  S.set(fS, fR);
   return true;
 }
 inline bool mypromote(const ARingRR& R,
@@ -231,7 +225,7 @@ inline bool mypromote(const ARingRR& R,
                       ARingCC::ElementType& fS)
 {
   (void) R;
-  S.set_from_doubles(fS, fR, 0);
+  S.set(fS, fR, 0);
   return true;
 }
 inline bool mypromote(const ARingRR& R,
@@ -240,7 +234,7 @@ inline bool mypromote(const ARingRR& R,
                       ARingCCC::ElementType& fS)
 {
   (void) R;
-  S.set_from_doubles(fS, fR, 0);
+  S.set(fS, fR, 0);
   return true;
 }
 /////////////////////////////////////////////////////
@@ -251,7 +245,7 @@ inline bool mypromote(const ARingRRR& R,
 {
   (void) R;
   auto fR1 = const_cast<ARingRRR::ElementType&>(fR);
-  S.set_from_BigReal(fS, &fR1);
+  S.set(fS, &fR1);
   return true;
 }
 
@@ -271,7 +265,7 @@ inline bool mypromote(const ARingRRR& R,
 {
   (void) R;
   auto fR1 = const_cast<ARingRRR::ElementType&>(fR);
-  S.set_from_BigReal(fS, &fR1);
+  S.set(fS, &fR1);
   return true;
 }
 /////////////////////////////////////////////////////
@@ -281,7 +275,7 @@ inline bool mypromote(const ARingRR& R,
                       ARingRRi::ElementType& fS)
 {
   (void) R;
-  S.set_from_double(fS, fR);
+  S.set(fS, fR);
   return true;
 }
 inline bool mypromote(const ARingRRR& R,
@@ -290,7 +284,7 @@ inline bool mypromote(const ARingRRR& R,
                       ARingRRi::ElementType& fS)
 {
   (void) R;
-  S.set_from_BigReal(fS, &fR);
+  S.set(fS, &fR);
   return true;
 }
 /////////////////////////////////////////////////////
@@ -300,7 +294,7 @@ inline bool mypromote(const ARingCC& R,
                       ARingCCC::ElementType& fS)
 {
   (void) R;
-  S.set_from_complex_double(fS, fR.re, fR.im);
+  S.set(fS, fR.re, fR.im);
   return true;
 }
 /////////////////////////////////////////////////////
@@ -311,7 +305,7 @@ inline bool mypromote(const ARingCCC& R,
 {
   (void) R;
   auto fR1 = const_cast<ARingCCC::ElementType&>(fR);
-  S.set_from_BigReals(fS, &fR1.re, &fR1.im);
+  S.set(fS, &fR1.re, &fR1.im);
   return true;
 }
 /////////////////////////////////////////////////////
@@ -320,7 +314,7 @@ inline bool mypromote(const ARingRR& R,
                       const ARingRR::ElementType& fR,
                       ARingCCi::ElementType& fS)
 {
-  S.set_from_double(fS, fR);
+  S.set(fS, fR);
   return true;
 }
 
@@ -329,7 +323,7 @@ inline bool mypromote(const ARingRRi& R,
                       const ARingRRi::ElementType& fR,
                       ARingCCi::ElementType& fS)
 {
-  S.set_from_Interval(fS, &fR);
+  S.set(fS, &fR);
   return true;
 }
 
@@ -338,7 +332,7 @@ inline bool mypromote(const ARingRRR& R,
                       const ARingRRR::ElementType& fR,
                       ARingCCi::ElementType& fS)
 {
-  S.set_from_BigReal(fS, &fR);
+  S.set(fS, &fR);
   return true;
 }
 inline bool mypromote(const ARingCC& R,
@@ -346,7 +340,7 @@ inline bool mypromote(const ARingCC& R,
                       const ARingCC::ElementType& fR,
                       ARingCCi::ElementType& fS)
 {
-  S.set_from_complex_double(fS, fR.re, fR.im);
+  S.set(fS, fR.re, fR.im);
   return true;
 }
 inline bool mypromote(const ARingCCC& R,
@@ -354,7 +348,7 @@ inline bool mypromote(const ARingCCC& R,
                       const ARingCCC::ElementType& fR,
                       ARingCCi::ElementType& fS)
 {
-  S.set_from_BigComplex(fS, &fR);
+  S.set(fS, &fR);
   return true;
 }
 /////////////////////////////////////////////////////
@@ -365,7 +359,7 @@ inline bool mylift(const ARingRRR& R,
                    const ARingRR::ElementType& gS)
 {
   (void) S;
-  R.set_from_double(result_gR, gS);
+  R.set(result_gR, gS);
   return true;
 }
 inline bool mylift(const ARingRRR& R,
@@ -391,7 +385,7 @@ inline bool mylift(const ARingRRR& R,
                    const ARingCC::ElementType& gS)
 {
   (void) S;
-  R.set_from_double(result_gR, gS.re);
+  R.set(result_gR, gS.re);
   return gS.im == 0;
 }
 /////////////////////////////////////////////////////
@@ -401,7 +395,7 @@ inline bool mylift(const ARingRR& R,
                    const ARingRR::ElementType& gS)
 {
   (void) S;
-  R.set_from_double(result_gR, gS);
+  R.set(result_gR, gS);
   return true;
 }
 inline bool mylift(const ARingRR& R,
@@ -411,7 +405,7 @@ inline bool mylift(const ARingRR& R,
 {
   (void) S;
   auto gS1 = const_cast<ARingRRR::ElementType&>(gS);
-  R.set_from_BigReal(result_gR, &gS1);
+  R.set(result_gR, &gS1);
   return true;
 }
 inline bool mylift(const ARingRR& R,
@@ -420,7 +414,7 @@ inline bool mylift(const ARingRR& R,
                    const ARingCCC::ElementType& gS)
 {
   auto gS1 = const_cast<ARingRRR::ElementType&>(S.realPartReference(gS));
-  R.set_from_BigReal(result_gR, &gS1);
+  R.set(result_gR, &gS1);
   return (S.real_ring().is_zero(S.imaginaryPartReference(gS)));
 }
 inline bool mylift(const ARingRR& R,
@@ -429,7 +423,7 @@ inline bool mylift(const ARingRR& R,
                    const ARingCC::ElementType& gS)
 {
   (void) S;
-  R.set_from_double(result_gR, gS.re);
+  R.set(result_gR, gS.re);
   return gS.im == 0;
 }
 /////////////////////////////////////////////////////
@@ -448,7 +442,7 @@ inline bool mylift(const ARingCCC& R,
                    const ARingCC::ElementType& gS)
 {
   (void) S;
-  R.set_from_complex_double(result_gR, gS.re, gS.im);
+  R.set(result_gR, gS.re, gS.im);
   return true;
 }
 inline bool mylift(const ARingCC& R,
@@ -458,7 +452,7 @@ inline bool mylift(const ARingCC& R,
 {
   (void) S;
   auto gS1 = const_cast<ARingCCC::ElementType&>(gS);
-  R.set_from_BigReals(result_gR, &gS1.re, &gS1.im);
+  R.set(result_gR, &gS1.re, &gS1.im);
   return true;
 }
 inline bool mylift(const ARingCC& R,
@@ -494,7 +488,7 @@ inline bool mylift(const ARingQQ& R,
                    const ARingRR::ElementType& fS)
 {
   (void) S;
-  return R.set_from_double(fR, fS);
+  return R.set(fR, fS);
 }
 
 inline bool mylift(const ARingQQ& R,
@@ -503,7 +497,7 @@ inline bool mylift(const ARingQQ& R,
                    const ARingRRR::ElementType& fS)
 {
   (void) S;
-  return R.set_from_BigReal(fR, &fS);
+  return R.set(fR, &fS);
 }
 
 // ZZ/p --> ZZ/p. 9 versions NONE OF THESE.

--- a/M2/Macaulay2/e/basic-rings/aring-translate.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-translate.hpp
@@ -100,7 +100,7 @@ inline constexpr bool has_set_from_ComplexInterval<
 }  // namespace detail
 
 template <typename RT>
-bool get_from_double(const RT& R, typename RT::ElementType& a, double b)
+bool try_set(const RT& R, typename RT::ElementType& a, double b)
 {
   if constexpr (detail::has_set_from_double<RT>)
     return R.set(a, b);
@@ -109,7 +109,7 @@ bool get_from_double(const RT& R, typename RT::ElementType& a, double b)
 }
 
 template <typename RT>
-bool get_from_BigReal(const RT& R, typename RT::ElementType& a, gmp_RR b)
+bool try_set(const RT& R, typename RT::ElementType& a, gmp_RR b)
 {
   if constexpr (detail::has_set_from_BigReal<RT>)
     return R.set(a, b);
@@ -118,7 +118,7 @@ bool get_from_BigReal(const RT& R, typename RT::ElementType& a, gmp_RR b)
 }
 
 template <typename RT>
-bool get_from_Interval(const RT& R, typename RT::ElementType& a, gmp_RRi b)
+bool try_set(const RT& R, typename RT::ElementType& a, gmp_RRi b)
 {
   if constexpr (detail::has_set_from_Interval<RT>)
     return R.set(a, b);
@@ -127,7 +127,7 @@ bool get_from_Interval(const RT& R, typename RT::ElementType& a, gmp_RRi b)
 }
 
 template <typename RT>
-bool get_from_complex_double(const RT& R,
+bool try_set(const RT& R,
                              typename RT::ElementType& a,
                              double re,
                              double im)
@@ -139,7 +139,7 @@ bool get_from_complex_double(const RT& R,
 }
 
 template <typename RT>
-bool get_from_BigComplex(const RT& R, typename RT::ElementType& a, gmp_CC b)
+bool try_set(const RT& R, typename RT::ElementType& a, gmp_CC b)
 {
   if constexpr (detail::has_set_from_BigComplex<RT>)
     return R.set(a, b);
@@ -148,7 +148,7 @@ bool get_from_BigComplex(const RT& R, typename RT::ElementType& a, gmp_CC b)
 }
 
 template <typename RT>
-bool get_from_ComplexInterval(const RT& R, typename RT::ElementType & a, gmp_CCi b)
+bool try_set(const RT& R, typename RT::ElementType & a, gmp_CCi b)
 {
   if constexpr (detail::has_set_from_ComplexInterval<RT>)
     return R.set(a, b);

--- a/M2/Macaulay2/e/basic-rings/aring.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring.hpp
@@ -102,6 +102,11 @@ template <class ARing>
 class SimpleARing : public RingInterface
 {
  public:
+  template <typename ET>
+  void copy(ET& result, const ET& a) const
+  {
+    static_cast<const ARing*>(this)->set(result, a);
+  }
   /**
    * \brief A wrapper class for ElementType
    */

--- a/M2/Macaulay2/e/basic-rings/aring.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring.hpp
@@ -236,14 +236,13 @@ class DummyRing : public SimpleARing<DummyRing>
 
   void init_set(elem &result, elem a) const { result = a; }
   void set(elem &result, elem a) const { result = a; }
-  void set_from_long(elem &result, long a) const { result = a; }
   void init(elem &result) const { result = 0; }
-  void set_from_mpz(elem &result, mpz_srcptr a) const
+  void set(elem &result, mpz_srcptr a) const
     {
       (void) a;
       result = 0;
     }
-  bool set_from_mpq(elem &result, mpq_srcptr a) const
+  bool set(elem &result, mpq_srcptr a) const
     {
       (void) result;
       (void) a;

--- a/M2/Macaulay2/e/basic-rings/reader.cpp
+++ b/M2/Macaulay2/e/basic-rings/reader.cpp
@@ -11,7 +11,7 @@ void Reader<ARingZZp>::read(std::istream& i, ElementType& result)
   mpz_t a;
   mpz_init(a);
   i >> a;
-  mRing.set_from_mpz(result, a);
+  mRing.set(result, a);
   mpz_clear(a);
 }
 }

--- a/M2/Macaulay2/e/basic-rings/vector-arithmetic.hpp
+++ b/M2/Macaulay2/e/basic-rings/vector-arithmetic.hpp
@@ -207,7 +207,7 @@ public:
 
     FieldElement one;
     mRing->init(one);
-    mRing->set_from_long(one, 1);
+    mRing->set(one, 1);
     if (not mRing->is_equal(svec[0], one))  // should be minus_one
       mRing->negate(b, b);
 
@@ -377,7 +377,7 @@ public:
     auto& svec = * elementArray(sparse); 
     for (auto i = 0; i < c.size(); ++i)
     {
-      mRing->set_from_long(svec[i], c[i]);
+      mRing->set(svec[i], c[i]);
     }
     return sparse;
   }
@@ -390,7 +390,7 @@ public:
     for (auto i = 0; i < c.size(); ++i)
     {
       __mpz_struct* x = const_cast<__mpz_struct*>(c[i].get_mpz_t());
-      mRing->set_from_mpz(svec[i], x);
+      mRing->set(svec[i], x);
     }
     return sparse;
   }
@@ -477,7 +477,7 @@ public:
     auto& svec = * elementArray(coeffs);
     FieldElement one;
     mRing->init(one);
-    mRing->set_from_long(one, 1);
+    mRing->set(one, 1);
     svec.emplace_back(one); // This grabs 'one' in cases where it is allocated...  I think...!
   }
 
@@ -486,7 +486,7 @@ public:
     auto& svec = * elementArray(coeffs);
     FieldElement minus_one;
     mRing->init(minus_one);
-    mRing->set_from_long(minus_one,-1);
+    mRing->set(minus_one,-1);
     svec.emplace_back(minus_one);
   }
 

--- a/M2/Macaulay2/e/basic-rings/vector-arithmetic.hpp
+++ b/M2/Macaulay2/e/basic-rings/vector-arithmetic.hpp
@@ -174,7 +174,7 @@ public:
     assert(comps[comps.size()-1] < dvec.size());
     
     auto len = comps.size();
-    for (ComponentIndex i = 0; i < len; i++) mRing->set(dvec[comps[i]],svec[i]);
+    for (ComponentIndex i = 0; i < len; i++) mRing->copy(dvec[comps[i]],svec[i]);
   }
 
    void denseCancelFromSparse(ElementArray& dense,
@@ -203,7 +203,7 @@ public:
 
     FieldElement b;
     mRing->init(b);
-    mRing->set(b, dvec[comps[0]]);
+    mRing->copy(b, dvec[comps[0]]);
 
     FieldElement one;
     mRing->init(one);

--- a/M2/Macaulay2/e/coeffrings.hpp
+++ b/M2/Macaulay2/e/coeffrings.hpp
@@ -60,14 +60,14 @@ class CoefficientRingZZp : public M2::SimpleARing<CoefficientRingZZp>
 #endif
   }
 
-  void set_from_long(elem &result, long a) const
+  void set(elem &result, long a) const
   {
     a = a % p;
     if (a < 0) a += p;
     result = log_table[a];
   }
   
-  void set_from_mpz(elem &result, mpz_t a) const
+  void set(elem &result, mpz_t a) const
   {
     mpz_t tmp;
     mpz_init_set_si(tmp, p);        // Convert int p to mpz_t
@@ -232,8 +232,9 @@ class CoefficientRingR
 
   void set_zero(elem &result) const { result = R->zero(); }
   void set(elem &result, elem a) const { result = a; }
-  void set_from_long(elem &result, long a) const { result = R->from_long(a); }
-  void set_from_mpz(elem &result, mpz_t a) const { result = R->from_int(a); }
+  void set(elem &result, long a) const { result = R->from_long(a); }
+  void set(elem &result, int a) const { result = R->from_long(a); }
+  void set(elem &result, mpz_t a) const { result = R->from_int(a); }
   bool is_zero(elem result) const { return R->is_zero(result); }
   bool is_equal(elem a, elem b) const { return R->is_equal(a, b); }
   bool is_unit(elem f) const { return R->is_unit(f); }

--- a/M2/Macaulay2/e/coeffrings.hpp
+++ b/M2/Macaulay2/e/coeffrings.hpp
@@ -231,6 +231,7 @@ class CoefficientRingR
   void clear(elem &result) const { (void) result; }
 
   void set_zero(elem &result) const { result = R->zero(); }
+  void copy(elem &result, elem a) const { result = a; }
   void set(elem &result, elem a) const { result = a; }
   void set(elem &result, long a) const { result = R->from_long(a); }
   void set(elem &result, int a) const { result = R->from_long(a); }

--- a/M2/Macaulay2/e/eigen.cpp
+++ b/M2/Macaulay2/e/eigen.cpp
@@ -103,7 +103,7 @@ void fill_from_MatrixXmp(const MatrixXmpCC& orig, LMatrixCC& result)
   result.resize(numrows, numcols);
   for (int r=0; r<numrows; r++)
     for (int c=0; c<numcols; c++)
-      result.ring().set_from_doubles(result.entry(r,c),
+      result.ring().set(result.entry(r,c),
         orig(r,c).real(),
         orig(r,c).imag());
 }
@@ -341,7 +341,7 @@ void fill_from_MatrixXmp(const MatrixXmpCCC& orig, LMatrixCCC& result)
   result.resize(numrows, numcols);
   for (int r=0; r<numrows; r++)
     for (int c=0; c<numcols; c++)
-      result.ring().set_from_complex_mpfr(result.entry(r,c),
+      result.ring().set(result.entry(r,c),
       orig(r,c).real().mpfr_srcptr(),
       orig(r,c).imag().mpfr_srcptr());
 }

--- a/M2/Macaulay2/e/rings/dpoly.cpp
+++ b/M2/Macaulay2/e/rings/dpoly.cpp
@@ -1496,7 +1496,7 @@ DRing *DRing::create(long p, int nvars0, const TowerPolynomial *ext0)
   return new DRing(p, nvars0, ext0);
 }
 
-void DRing::set_from_int(TowerPolynomial &result, mpz_srcptr r)
+void DRing::set(TowerPolynomial &result, mpz_srcptr r)
 {
   mpz_t a;
   mpz_init(a);
@@ -1507,7 +1507,7 @@ void DRing::set_from_int(TowerPolynomial &result, mpz_srcptr r)
   result = D.from_long(level, c);
 }
 
-bool DRing::set_from_mpq(TowerPolynomial &result, mpq_srcptr r)
+bool DRing::set(TowerPolynomial &result, mpq_srcptr r)
 {
   // returns false if r doesn't lift
   mpz_t a;

--- a/M2/Macaulay2/e/rings/dpoly.hpp
+++ b/M2/Macaulay2/e/rings/dpoly.hpp
@@ -308,16 +308,16 @@ class DRing : public our_new_delete
     result = D.var(level, n);
   }
 
-  void set_from_long(TowerPolynomial &result, long r)
+  void set(TowerPolynomial &result, long r)
   {
     r = r % P;
     if (r < 0) r += P;
     result = D.from_long(level, r);
   }
 
-  void set_from_int(TowerPolynomial &result, mpz_srcptr r);  // written
+  void set(TowerPolynomial &result, mpz_srcptr r);  // written
 
-  bool set_from_mpq(TowerPolynomial &result, mpq_srcptr r);  // written
+  bool set(TowerPolynomial &result, mpq_srcptr r);  // written
 
   void set_random(TowerPolynomial &result) { result = D.random(level); }
   void elem_text_out(buffer &o,

--- a/M2/Macaulay2/e/rings/tower.cpp
+++ b/M2/Macaulay2/e/rings/tower.cpp
@@ -106,21 +106,21 @@ M2_arrayint Tower::support(const ring_elem a) const
 ring_elem Tower::from_long(long n) const
 {
   TowerPolynomial f;
-  D->set_from_long(f, n);
+  D->set(f, n);
   return TOWER_RINGELEM(f);
 }
 
 ring_elem Tower::from_int(mpz_srcptr n) const
 {
   TowerPolynomial f;
-  D->set_from_int(f, n);
+  D->set(f, n);
   return TOWER_RINGELEM(f);
 }
 
 bool Tower::from_rational(mpq_srcptr q, ring_elem &result) const
 {
   TowerPolynomial f;
-  if (not D->set_from_mpq(f, q)) return false;
+  if (not D->set(f, q)) return false;
   result = TOWER_RINGELEM(f);
   return true;
 }

--- a/M2/Macaulay2/e/schreyer-resolutions/res-f4-m2-interface.cpp
+++ b/M2/Macaulay2/e/schreyer-resolutions/res-f4-m2-interface.cpp
@@ -556,7 +556,7 @@ void setDMatFromSparseMatrixGenerator(Gen& G, DMat<RingType>& M)
     {
       for (int j=0; j<i.components().size(); ++j)
       {
-        M.ring().set_from_long(M.entry(i.components()[j], i.column()), i.coefficients()[j]);
+        M.ring().set(M.entry(i.components()[j], i.column()), i.coefficients()[j]);
       }
     }
 }
@@ -570,7 +570,7 @@ void setDMatFromSparseMatrixGeneratorTransposed(Gen& G, DMat<RingType>& M)
     {
       for (int j=0; j<i.components().size(); ++j)
       {
-        M.ring().set_from_long(M.entry(i.column(), i.components()[j]), i.coefficients()[j]);
+        M.ring().set(M.entry(i.column(), i.components()[j]), i.coefficients()[j]);
       }
     }
 }

--- a/M2/Macaulay2/e/unit-tests/ARingCCCTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingCCCTest.cpp
@@ -38,7 +38,7 @@ void getElement<M2::ARingCCC>(const M2::ARingCCC& C,
                               M2::ARingCCC::ElementType& result)
 {
   if (index < 50)
-    C.set_from_long(result, index - 25);
+    C.set(result, index - 25);
   else
     C.random(result);
 }

--- a/M2/Macaulay2/e/unit-tests/ARingCCTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingCCTest.cpp
@@ -31,7 +31,7 @@ void getElement<M2::ARingCC>(const M2::ARingCC& C,
                              M2::ARingCC::ElementType& result)
 {
   if (index < 50)
-    C.set_from_long(result, index - 25);
+    C.set(result, index - 25);
   else
     C.random(result);
 }

--- a/M2/Macaulay2/e/unit-tests/ARingGFTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingGFTest.cpp
@@ -88,7 +88,7 @@ TEST(ARingGFFlint, create)
   //    for (int i=-5; i<R.characteristic(); i++)
   for (int i = -130; i < 130; i++)
     {
-      R.set_from_long(a, i);
+      R.set(a, i);
       M2_arrayint coeffs = R.fieldElementToM2Array(a);
       EXPECT_EQ(coeffs->len, 3);
       int imodp = i % 5;

--- a/M2/Macaulay2/e/unit-tests/ARingQQFlintTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingQQFlintTest.cpp
@@ -20,7 +20,7 @@ void getElement<M2::ARingQQFlint>(const M2::ARingQQFlint& R,
                                   M2::ARingQQFlint::ElementType& result)
 {
   if (index < 50)
-    R.set_from_long(result, index - 25);
+    R.set(result, index - 25);
   else
     {
       R.random(result);

--- a/M2/Macaulay2/e/unit-tests/ARingQQGmpTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingQQGmpTest.cpp
@@ -20,7 +20,7 @@ void getElement<M2::ARingQQGMP>(const M2::ARingQQGMP& R,
                                 M2::ARingQQGMP::ElementType& result)
 {
   if (index < 50)
-    R.set_from_long(result, index - 25);
+    R.set(result, index - 25);
   else
     {
       R.random(result);

--- a/M2/Macaulay2/e/unit-tests/ARingRRRTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingRRRTest.cpp
@@ -36,7 +36,7 @@ void getElement<M2::ARingRRR>(const M2::ARingRRR& R,
                               M2::ARingRRR::ElementType& result)
 {
   if (index < 50)
-    R.set_from_long(result, index - 25);
+    R.set(result, index - 25);
   else
     R.random(result);
 }
@@ -44,7 +44,7 @@ void getElement<M2::ARingRRR>(const M2::ARingRRR& R,
 // void getElementRRR(const M2::ARingRRR&  R, int index,
 // M2::ARingRRR::ElementType& result)
 //{
-//  if (index < 50) R.set_from_long(result, index-25);
+//  if (index < 50) R.set(result, index-25);
 //  else R.random(result);
 //}
 

--- a/M2/Macaulay2/e/unit-tests/ARingRRTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingRRTest.cpp
@@ -32,7 +32,7 @@ void getElement<M2::ARingRR>(const M2::ARingRR& R,
                              M2::ARingRR::ElementType& result)
 {
   if (index < 50)
-    R.set_from_long(result, index - 25);
+    R.set(result, index - 25);
   else
     R.random(result);
 }
@@ -40,7 +40,7 @@ void getElement<M2::ARingRR>(const M2::ARingRR& R,
 // void getElementRR(const M2::ARingRR&  R, int index, M2::ARingRR::ElementType&
 // result)
 //{
-//  if (index < 50) R.set_from_long(result, index-25);
+//  if (index < 50) R.set(result, index-25);
 //  else R.random(result);
 //}
 

--- a/M2/Macaulay2/e/unit-tests/ARingRRiTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingRRiTest.cpp
@@ -45,7 +45,7 @@ void getElement<M2::ARingRRi>(const M2::ARingRRi& R,
                               M2::ARingRRi::ElementType& result)
 {
   if (index < 50)
-    R.set_from_long(result, index - 25);
+    R.set(result, index - 25);
   else
     R.random(result);
 }

--- a/M2/Macaulay2/e/unit-tests/ARingTest.hpp
+++ b/M2/Macaulay2/e/unit-tests/ARingTest.hpp
@@ -41,9 +41,9 @@ void testSomeMore(const T& R)
   R.init(c);
   R.init(d);
 
-  R.set_from_long(a, 27);
-  R.set_from_long(b, static_cast<int>(R.characteristic()) - 11);
-  R.set_from_long(c, 16);
+  R.set(a, 27);
+  R.set(b, static_cast<int>(R.characteristic()) - 11);
+  R.set(c, 16);
   R.add(d, a, b);
 
   buffer o;
@@ -105,20 +105,20 @@ void testCoercions(const T& R)
   mpz_init(base);
   mpq_init(n1);
 
-  // set_from_mpz
+  // set
   mpz_set_str(base, "2131236127486324783264782364", 10);
-  R.set_from_mpz(c, base);
+  R.set(c, base);
   for (int i = -1000; i < 1000; i++)
     {
       mpz_set_si(m, i);
       mpz_add(m, m, base);   // m = base + i
-      R.set_from_mpz(a, m);  // a = (base + i) mod charac
-      R.set_from_long(b, i);
+      R.set(a, m);  // a = (base + i) mod charac
+      R.set(b, i);
       R.add(b, c, b);                 // b = (base mod charac) + (i mod charac)
       EXPECT_TRUE(R.is_equal(a, b));  // a, b should be equal
     }
 
-  // set_from_mpq
+  // set
   for (int i = 1; i < 300; i++)
     {
       mpq_set_si(n1, 43999, i);
@@ -127,10 +127,10 @@ void testCoercions(const T& R)
       // check that (43999 mod charac)/(i mod charac) == n1 mod charac
       // if (i mod charac) is not zero.
       if (R.characteristic() == 0 or (i % R.characteristic()) == 0) continue;
-      bool ok = R.set_from_mpq(a, n1);
+      bool ok = R.set(a, n1);
       EXPECT_TRUE(ok);
-      R.set_from_long(b, 43999);
-      R.set_from_long(c, i);
+      R.set(b, 43999);
+      R.set(c, i);
       if (!R.is_zero(c))
         {
           R.divide(c, b, c);
@@ -282,7 +282,7 @@ void testMultiply(const T& R, int ntrials)
   R.init(c);
   R.init(d);
   R.init(zero);
-  R.set_from_long(zero, 0);
+  R.set(zero, 0);
   for (int i = 0; i < ntrials; i++)
     {
       gen.nextElement(a);
@@ -310,7 +310,7 @@ void testDivide(const T& R, int ntrials)
   R.init(c);
   R.init(d);
   R.init(zero);
-  R.set_from_long(zero, 0);
+  R.set(zero, 0);
   for (int i = 0; i < ntrials; i++)
     {
       // c = a*b
@@ -340,7 +340,7 @@ void testReciprocal(const T& R, int ntrials)
   R.init(b);
   R.init(c);
   R.init(one);
-  R.set_from_long(one, 1);
+  R.set(one, 1);
   for (int i = 0; i < ntrials; i++)
     {
       // c = 1/a
@@ -379,7 +379,7 @@ void testPower(const T& R, int ntrials)
   R.init(b);
   R.init(c);
   R.init(d);
-  R.set_from_long(one, 1);
+  R.set(one, 1);
   for (int i = 0; i < ntrials; i++)
     {
       gen.nextElement(a);

--- a/M2/Macaulay2/e/unit-tests/ARingZZTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingZZTest.cpp
@@ -19,11 +19,11 @@ void getElement<M2::ARingZZ>(const M2::ARingZZ& R,
                              M2::ARingZZ::ElementType& result)
 {
   if (index < 50)
-    R.set_from_long(result, index - 25);
+    R.set(result, index - 25);
   else
     {
       gmp_ZZ a = getRandomInteger();
-      R.set_from_mpz(result, a);
+      R.set(result, a);
     }
 }
 

--- a/M2/Macaulay2/e/unit-tests/ARingZZpTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingZZpTest.cpp
@@ -34,11 +34,11 @@ void getElement<M2::ARingZZp>(const M2::ARingZZp& R,
                               M2::ARingZZp::ElementType& result)
 {
   if (index < 50)
-    R.set_from_long(result, index - 25);
+    R.set(result, index - 25);
   else
     {
       gmp_ZZ a = getRandomInteger();
-      R.set_from_mpz(result, a);
+      R.set(result, a);
     }
 }
 
@@ -51,7 +51,7 @@ void testCoerceToLongInteger(const RT& R)
     {
       typename RT::ElementType a;
       R.init(a);
-      R.set_from_long(a, i);
+      R.set(a, i);
       long b = R.coerceToLongInteger(a);
       if (b < 0) b += R.characteristic();
       EXPECT_EQ(b, i);
@@ -60,7 +60,7 @@ void testCoerceToLongInteger(const RT& R)
     {
       typename RT::ElementType a;
       R.init(a);
-      R.set_from_long(a, i);
+      R.set(a, i);
       long b = R.coerceToLongInteger(a);
       if (b < 0) b += R.characteristic();
       EXPECT_EQ(b, i);
@@ -153,11 +153,11 @@ void getElement<M2::ARingZZpFFPACK>(const M2::ARingZZpFFPACK& R,
                                     M2::ARingZZpFFPACK::ElementType& result)
 {
   if (index < 50)
-    R.set_from_long(result, index - 25);
+    R.set(result, index - 25);
   else
     {
       gmp_ZZ a = getRandomInteger();
-      R.set_from_mpz(result, a);
+      R.set(result, a);
     }
 }
 
@@ -173,9 +173,9 @@ TEST(ARingZZpFFPACK, create)
 
   M2::ARingZZpFFPACK::ElementType a;
   R.init(a);
-  R.set_from_long(a, 99);
-  R.set_from_long(a, 101);
-  R.set_from_long(a, 103);
+  R.set(a, 99);
+  R.set(a, 101);
+  R.set(a, 103);
   R.clear(a);
 }
 
@@ -268,7 +268,7 @@ TEST(ARingZZp, read)
   R.init(b);
   R.init(c);
   reader.read(i, b);
-  R.set_from_long(c, 3);
+  R.set(c, 3);
 
   EXPECT_TRUE(R.is_equal(b, c));
 }
@@ -283,11 +283,11 @@ void getElement<M2::ARingZZpFlint>(const M2::ARingZZpFlint& R,
                                    M2::ARingZZpFlint::ElementType& result)
 {
   if (index < 50)
-    R.set_from_long(result, index - 25);
+    R.set(result, index - 25);
   else
     {
       gmp_ZZ a = getRandomInteger();
-      R.set_from_mpz(result, a);
+      R.set(result, a);
     }
 }
 
@@ -300,9 +300,9 @@ TEST(ARingZZpFlint, create)
 
   M2::ARingZZpFlint::ElementType a;
   R.init(a);
-  R.set_from_long(a, 99);
-  R.set_from_long(a, 101);
-  R.set_from_long(a, 103);
+  R.set(a, 99);
+  R.set(a, 101);
+  R.set(a, 103);
   R.clear(a);
 }
 

--- a/M2/Macaulay2/e/unit-tests/DMatZZpTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/DMatZZpTest.cpp
@@ -18,7 +18,7 @@ TEST(DMatZZp, create)
   RingZZp::ElementType a, b;
   R->init(a);
   R->init(b);
-  R->set_from_long(a, 13);
+  R->set(a, 13);
   R->set(M.entry(0, 2), a);
 
   R->set(b, M.entry(0, 2));
@@ -39,7 +39,7 @@ TEST(DMatZZp, submatrix)
   R->init(a);
   R->init(b);
 
-  R->set_from_long(a, 13);
+  R->set(a, 13);
   R->set(M.entry(0, 2), a);
 
   R->set(b, M.entry(0, 2));

--- a/M2/Macaulay2/e/unit-tests/DMatZZpTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/DMatZZpTest.cpp
@@ -19,9 +19,9 @@ TEST(DMatZZp, create)
   R->init(a);
   R->init(b);
   R->set(a, 13);
-  R->set(M.entry(0, 2), a);
+  R->copy(M.entry(0, 2), a);
 
-  R->set(b, M.entry(0, 2));
+  R->copy(b, M.entry(0, 2));
   EXPECT_TRUE(R->is_equal(a, b));
 }
 
@@ -40,15 +40,15 @@ TEST(DMatZZp, submatrix)
   R->init(b);
 
   R->set(a, 13);
-  R->set(M.entry(0, 2), a);
+  R->copy(M.entry(0, 2), a);
 
-  R->set(b, M.entry(0, 2));
+  R->copy(b, M.entry(0, 2));
   EXPECT_TRUE(R->is_equal(a, b));
 
   // No check is done that there is no aliasing here...
   // Should there be
   submatrix(M, 0, 0, 1, 1) = submatrix(M, 0, 2, 1, 1);
-  R->set(b, M.entry(0, 0));
+  R->copy(b, M.entry(0, 0));
   EXPECT_TRUE(R->is_equal(a, b));
 
   submatrix(M, 0, 0, 2, 2) = 0;
@@ -57,14 +57,14 @@ TEST(DMatZZp, submatrix)
   submatrix(M, 0, 2, 2, 2) = 0;
   EXPECT_TRUE(MatrixOps::isZero(M));
 
-  R->set(M.entry(4, 4), a);
+  R->copy(M.entry(4, 4), a);
   EXPECT_FALSE(MatrixOps::isZero(M));
 
   submatrix(M) = 0;
   EXPECT_TRUE(MatrixOps::isZero(M));
 
   MatZZp N(*R, 2, 2);
-  R->set(N.entry(0, 0), a);
+  R->copy(N.entry(0, 0), a);
   displayMat(N);
   std::cout << std::endl;
   displayMat(M);

--- a/M2/Macaulay2/e/unit-tests/fromStream.cpp
+++ b/M2/Macaulay2/e/unit-tests/fromStream.cpp
@@ -22,7 +22,7 @@ std::istream &fromStream<M2::ARingZZp>(std::istream &i,
 {
   int a;
   i >> a;
-  R.set_from_long(result, a);
+  R.set(result, a);
   return i;
 }
 


### PR DESCRIPTION
This was originally part of #62, but I split it off.

We rename the various `set_from_*` methods (like `set_from_long`, `set_from_double`, etc.) to just `set`.  The method names were redundant since the thing we're setting from is clear from the second argument.  This point come up in our C++ factoring group discussion last Friday.

Similarly, the various `get_from_*` methods are renamed to `try_set`, since that's what they do -- they try calling `set` and return false if they can't.

One little wrinkle -- `GFM2` (the "New" strategy for `GF`) uses `int` for its elements, but not how you'd expect.  1 isn't actually 1, but `a^1`, where `a` is a generator for the multplicative group of units. So there was some ambiguity -- should `set(x, 1)` mean "set x to be 1" or "set x to be a^1"?

We made the decision that, for consistency with all the other rings where setting from an `int` means promoting from `ZZ`, it should be the former.  That messed up a few algorithms that called `set` to mean the latter thing, so we switched them to use `copy` instead.

Draft for now to test the builds

