### PR TITLE
Add some CCi unit tests

### DIFF
--- a/M2/Macaulay2/e/basic-rings/aring-CCi.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-CCi.hpp
@@ -244,6 +244,14 @@ class ARingCCi : public SimpleARing<ARingCCi>
     {
       return a.im;
     }
+  void set_real_part_from_doubles(ElementType& c, double left, double right) const
+  {
+    mpfi_interv_d(&c.re, left, right);
+  }
+  void set_imaginary_part_from_doubles(ElementType& c, double left, double right) const
+  {
+    mpfi_interv_d(&c.im, left, right);
+  }
   void set_real_part(ElementType& c, ARingRRi::ElementType& a) const
     {
       mpfi_set(&c.re, &a);

--- a/M2/Macaulay2/e/basic-rings/aring-CCi.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-CCi.hpp
@@ -33,7 +33,7 @@ class ARingCCi : public SimpleARing<ARingCCi>
   typedef cci_struct elem;
   typedef elem ElementType;
 
-  ARingCCi(unsigned long precision) : mPrecision(precision) {}
+  ARingCCi(unsigned long precision = 53) : mPrecision(precision) {}
   // ring informational
   size_t characteristic() const { return 0; }
   unsigned long get_precision() const { return mPrecision; }

--- a/M2/Macaulay2/e/basic-rings/aring-RRi.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-RRi.hpp
@@ -148,7 +148,13 @@ class ARingRRi : public SimpleARing<ARingRRi>
     mpfi_set_d(&result, a);
     return true;
   }
-    
+
+  bool set_from_doubles(ElementType &result, double left, double right) const
+  {
+    mpfi_interv_d(&result, left, right);
+    return true;
+  }
+
   bool set(ElementType &result, gmp_RR a) const
   {
     mpfi_set_fr(&result, a);

--- a/M2/Macaulay2/e/basic-rings/aring-RRi.hpp
+++ b/M2/Macaulay2/e/basic-rings/aring-RRi.hpp
@@ -30,7 +30,7 @@ class ARingRRi : public SimpleARing<ARingRRi>
   typedef __mpfi_struct elem;
   typedef elem ElementType;
 
-  ARingRRi(unsigned long precision) : mPrecision(precision) {}
+  ARingRRi(unsigned long precision = 53) : mPrecision(precision) {}
   // ring informational
   size_t characteristic() const { return 0; }
   unsigned long get_precision() const { return mPrecision; }

--- a/M2/Macaulay2/e/unit-tests/ARingCCiTest.cpp
+++ b/M2/Macaulay2/e/unit-tests/ARingCCiTest.cpp
@@ -1,0 +1,42 @@
+#include <gtest/gtest.h>
+
+#include "basic-rings/aring-CCi.hpp"
+#include "unit-tests/ARingTest.hpp"
+
+TEST(ARingCCi, create)
+{
+  M2::ARingCCi C1, C2(100);
+  EXPECT_EQ(C1.get_precision(), 53);
+  EXPECT_EQ(C2.get_precision(), 100);
+  EXPECT_EQ(C1.characteristic(), 0);
+  EXPECT_EQ(C2.characteristic(), 0);
+  EXPECT_EQ(ringName(C1), "ACCi_53");
+  EXPECT_EQ(ringName(C2), "ACCi_100");
+}
+
+TEST(ARingCCi, isZero)
+{
+  M2::ARingCCi C;
+  M2::ARingCCi::ElementType a;
+  C.init(a);
+
+  // a = 0
+  C.set_from_long(a, 0);
+  EXPECT_TRUE(C.is_zero(a));
+
+  // a = [0,1]
+  C.set_real_part_from_doubles(a, 0, 1);
+  EXPECT_FALSE(C.is_zero(a));
+
+  // a = 1
+  C.set_real_part_from_doubles(a, 1, 1);
+  EXPECT_FALSE(C.is_zero(a));
+
+  // a = 1 + [0,1]*ii
+  C.set_imaginary_part_from_doubles(a, 0, 1);
+  EXPECT_FALSE(C.is_zero(a));
+
+  // a = 1 + ii
+  C.set_imaginary_part_from_doubles(a, 1, 1);
+  EXPECT_FALSE(C.is_zero(a));
+}

--- a/M2/Macaulay2/e/unit-tests/Makefile.files
+++ b/M2/Macaulay2/e/unit-tests/Makefile.files
@@ -15,6 +15,7 @@ UNITTEST_CCFILES := \
     ARingQQGmpTest \
     ARingRRTest \
     ARingCCTest \
+    ARingCCiTest \
     ARingRRRTest \
     ARingRRiTest \
     ARingCCCTest \

--- a/M2/Macaulay2/e/unit-tests/Makefile.in
+++ b/M2/Macaulay2/e/unit-tests/Makefile.in
@@ -26,8 +26,10 @@ fullCheck: $(UNITTEST_TARGET)
 $(UNITTEST_TARGET) : $(UNITTEST_OBJECT_FILES) $(LIBENGINE)
 	@CXX@ $(LDFLAGS) $^ $(LOADLIBES) -o $@
 
+GTEST_FILTER = *
+
 runtests: $(UNITTEST_TARGET)
-	time ./$(UNITTEST_TARGET)
+	time ./$(UNITTEST_TARGET) --gtest_filter="$(GTEST_FILTER)"
 
 MORE_OPTIONS = -Wno-cast-qual
 COMPILE.cc += $(MORE_OPTIONS)


### PR DESCRIPTION
Here's the `CCi` unit tests that I put together during the 8/28 C++ refactoring group meeting.

I cleaned it up a bit afterwards:
* Rebased on top of `arings`
* Added new `CCi` real/imaginary part setters taking two doubles so we don't need to even deal with `RRi` directly
* Used `mpfi_interv_d` to construct intervals from two doubles instead of separate `mpfi_set_d` and `mpfi_put_d` calls, which also preserves the left/right orientation as opposed to `mpfi_put_d`, which just grows the interval.
* Coverage is now green!

<img width="1176" height="51" alt="image" src="https://github.com/user-attachments/assets/b9badb42-2e3d-4204-9535-5565a3153222" />
